### PR TITLE
:test_tube: add OCR annotation and metrics pipeline

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,6 @@ repos:
         name: ruff (python)
         args: ["--fix", "--exit-non-zero-on-fix", '--ignore', 'E501']
   - repo: https://github.com/psf/black
-    rev: 25.1.0
+    rev: 26.3.1
     hooks:
       - id: black

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,9 @@ dev = [
     "pytest-cov>=4.1.0",
 ]
 
+[tool.black]
+target-version = ["py311"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/trocr_handwritten/README.md
+++ b/trocr_handwritten/README.md
@@ -707,6 +707,65 @@ text, input_tokens, output_tokens = provider.ocr_image(image_path, prompt)
 print(text)
 ```
 
+### 🏷️ Annotating OCR transcriptions
+
+The OCR annotation tool displays each image alongside a textarea pre-filled with the LLM transcription (`.md` file). You correct the text and save — each sample is assigned to a split (train 70%, test 20%, dev 10%).
+
+```bash
+python -m trocr_handwritten.llm.annotate data/processed/images/
+```
+
+To import existing annotated data from the legacy format (`{subfolder}/images/*.jpg` + `label/*.txt`):
+
+```bash
+python -m trocr_handwritten.llm.annotate data/processed/images/ \
+    --import-dir data/ocr/images/20250127-annotated/
+```
+
+Saved annotations go to `data/ocr/{split}/`:
+- `images/{subfolder}/filename.jpg`
+- `labels/{subfolder}/filename.txt`
+- `annotations.json`
+
+| Shortcut | Action |
+|----------|--------|
+| Ctrl+S | Save transcription |
+| Left / Right | Navigate images |
+
+### 📊 OCR Metrics
+
+Evaluate OCR quality by comparing predictions with reference labels. The workflow is:
+
+1. Apply the LLM OCR on the test images (generates `.md` files next to images):
+
+```bash
+python -m trocr_handwritten.llm.ocr \
+    --input_dir data/ocr/test/images \
+    --provider gemini
+```
+
+2. Compare predictions vs labels:
+
+```bash
+python -m trocr_handwritten.llm.metrics \
+    --predictions data/ocr/test/images \
+    --labels data/ocr/test/labels
+```
+
+Metrics computed per image and per subfolder:
+- **CER** (Character Error Rate)
+- **WER** (Word Error Rate)
+- **Levenshtein distance** (character edits)
+- **Exact match** (% perfectly identical)
+
+Output:
+```
+      Subfolder      CER     WER     Lev  Exact%     N
+    Plein Texte   0.0450  0.1210    12.3    8.0%    25
+          Marge   0.0820  0.1950    18.7    4.0%    10
+            ALL   0.0520  0.1380    14.2    6.5%    35
+```
+
 ## 🗃️ Named Entity Recognition (NER) with LLM
 
 ### 🎯 Objective

--- a/trocr_handwritten/llm/annotate.py
+++ b/trocr_handwritten/llm/annotate.py
@@ -57,9 +57,7 @@ def _read_inference(image_path, inference_ext):
     return ""
 
 
-OCR_ANNOTATE_CSS = (
-    ANNOTATE_BASE_CSS
-    + """
+OCR_ANNOTATE_CSS = ANNOTATE_BASE_CSS + """
 .main { flex: 1; display: flex; min-height: 0; overflow: hidden; }
 .split-left { flex: 1; display: flex; justify-content: center; align-items: center;
               overflow: auto; padding: 0.5rem; background: #1a1a2e; }
@@ -73,7 +71,6 @@ OCR_ANNOTATE_CSS = (
 .info { font-size: 0.8rem; color: #8892b0; padding: 0.3rem 0.5rem; text-align: center; }
 .info strong { color: #ccd6f6; }
 """
-)
 
 OCR_ANNOTATE_JS = """
 const textarea = document.getElementById('transcription');

--- a/trocr_handwritten/llm/annotate.py
+++ b/trocr_handwritten/llm/annotate.py
@@ -96,6 +96,7 @@ function saveText() {
         return r.json();
     }).then(data => {
         showToast('Saved');
+        setTimeout(() => { window.location.href = '/annotate?idx=' + PAGE_IDX; }, 500);
     }).catch(err => {
         showToast('Error: ' + err.message);
     });
@@ -304,7 +305,10 @@ class OCRAnnotationHandler(SimpleHTTPRequestHandler):
         self.state["n_annotated"] = sum(1 for a in annotations if a.get("text"))
         save_split_annotations(annotations, OCR_DIR)
 
-        self._send_json({"ok": True})
+        if image_path in self.state["images"]:
+            self.state["images"].remove(image_path)
+
+        self._send_json({"ok": True, "total": len(self.state["images"])})
 
     def _send_html(self, html):
         data = html.encode("utf-8")
@@ -339,16 +343,27 @@ def annotate(images_dir, inference_ext=".md", import_dir=None, port=8790):
         import_legacy_annotations(import_dir, str(OCR_DIR), logger)
 
     images_root = Path(images_dir).resolve()
-    images = collect_images_recursive(images_dir)
-    if not images:
+    all_images = collect_images_recursive(images_dir)
+    if not all_images:
         logger.error(f"No images found in {images_dir}")
         return
 
-    logger.info(f"Found {len(images)} images in {images_dir}")
-
     annotations = load_split_annotations(OCR_DIR)
-    n_annotated = sum(1 for a in annotations if a.get("text"))
-    logger.info(f"Already annotated: {n_annotated}")
+    annotated_keys = {
+        (a["filename"], a.get("subfolder", "")) for a in annotations if a.get("text")
+    }
+
+    images = [
+        img
+        for img in all_images
+        if (img.name, _get_subfolder(img, images_root)) not in annotated_keys
+    ]
+
+    n_annotated = len(annotated_keys)
+    logger.info(
+        f"Found {len(all_images)} images, {n_annotated} already annotated, "
+        f"{len(images)} remaining"
+    )
 
     state = {
         "images": images,

--- a/trocr_handwritten/llm/annotate.py
+++ b/trocr_handwritten/llm/annotate.py
@@ -1,0 +1,400 @@
+import argparse
+import json
+import shutil
+import webbrowser
+from functools import partial
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+from trocr_handwritten.utils.annotation import (
+    assign_split,
+    collect_images_recursive,
+    load_split_annotations,
+    save_split_annotations,
+    ANNOTATE_BASE_CSS,
+)
+from trocr_handwritten.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+OCR_DIR = Path("data/ocr")
+
+
+def _get_subfolder(image_path, images_root):
+    """
+    Extract the subfolder name (class) from an image path relative to images_root.
+    e.g. data/processed/images/DOC/Plein Texte/000.jpg → "Plein Texte"
+
+    Args:
+        image_path: Full path to the image
+        images_root: Root images directory
+
+    Returns:
+        str: Subfolder name, or "" if at root
+    """
+    rel = image_path.relative_to(Path(images_root).resolve())
+    parts = rel.parts
+    if len(parts) >= 2:
+        return parts[-2]
+    return ""
+
+
+def _read_inference(image_path, inference_ext):
+    """
+    Read the inference file next to an image.
+
+    Args:
+        image_path: Path to the image
+        inference_ext: Extension of inference files (e.g. ".md")
+
+    Returns:
+        str: Inference text, or empty string
+    """
+    inf_path = image_path.with_suffix(inference_ext)
+    if inf_path.exists():
+        return inf_path.read_text(encoding="utf-8").strip()
+    return ""
+
+
+OCR_ANNOTATE_CSS = (
+    ANNOTATE_BASE_CSS
+    + """
+.main { flex: 1; display: flex; min-height: 0; overflow: hidden; }
+.split-left { flex: 1; display: flex; justify-content: center; align-items: center;
+              overflow: auto; padding: 0.5rem; background: #1a1a2e; }
+.split-left img { max-width: 100%; max-height: 100%; object-fit: contain; }
+.split-right { flex: 1; display: flex; flex-direction: column; padding: 0.5rem;
+               background: #0d1117; }
+.split-right textarea { flex: 1; background: #161b22; color: #e6edf3; border: 1px solid #30363d;
+                        border-radius: 6px; padding: 1rem; font-family: monospace;
+                        font-size: 14px; line-height: 1.6; resize: none; outline: none; }
+.split-right textarea:focus { border-color: #64ffda; }
+.info { font-size: 0.8rem; color: #8892b0; padding: 0.3rem 0.5rem; text-align: center; }
+.info strong { color: #ccd6f6; }
+"""
+)
+
+OCR_ANNOTATE_JS = """
+const textarea = document.getElementById('transcription');
+
+function showToast(msg) {
+    const toast = document.getElementById('toast');
+    toast.textContent = msg;
+    toast.classList.add('show');
+    setTimeout(() => toast.classList.remove('show'), 1500);
+}
+
+function saveText() {
+    const text = textarea.value;
+    fetch('/save', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/json'},
+        body: JSON.stringify({ idx: PAGE_IDX, text: text }),
+    }).then(r => {
+        if (!r.ok) throw new Error(r.status);
+        return r.json();
+    }).then(data => {
+        showToast('Saved');
+    }).catch(err => {
+        showToast('Error: ' + err.message);
+    });
+}
+
+function navigateTo(idx) {
+    if (idx >= 0 && idx < TOTAL_PAGES) {
+        window.location.href = '/annotate?idx=' + idx;
+    }
+}
+
+document.addEventListener('keydown', (e) => {
+    if ((e.ctrlKey || e.metaKey) && e.key === 's') {
+        e.preventDefault();
+        saveText();
+        return;
+    }
+    if (e.target.tagName === 'TEXTAREA') return;
+
+    if (e.key === 'ArrowRight' || e.key === 'n') {
+        e.preventDefault();
+        navigateTo(PAGE_IDX + 1);
+    } else if (e.key === 'ArrowLeft' || e.key === 'p') {
+        e.preventDefault();
+        navigateTo(PAGE_IDX - 1);
+    }
+});
+
+textarea.focus();
+"""
+
+
+def _build_annotate_html(filename, subfolder, idx, total, n_annotated, initial_text):
+    """Build the OCR annotation page HTML."""
+    text_escaped = (
+        initial_text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+    )
+
+    js = OCR_ANNOTATE_JS.replace("PAGE_IDX", str(idx)).replace(
+        "TOTAL_PAGES", str(total)
+    )
+
+    return f"""<!DOCTYPE html>
+<html><head><meta charset="utf-8"><title>OCR Annotate {idx + 1}/{total}</title>
+<style>{OCR_ANNOTATE_CSS}</style></head><body>
+<div class="header">
+  <h1>OCR Annotation</h1>
+  <div class="header-right">
+    <span class="stats">annotated={n_annotated}/{total}</span>
+    <span class="progress">{idx + 1} / {total}</span>
+  </div>
+</div>
+<div class="info"><strong>{filename}</strong> &mdash; {subfolder}</div>
+<div class="main">
+  <div class="split-left">
+    <img src="/image?idx={idx}" />
+  </div>
+  <div class="split-right">
+    <textarea id="transcription">{text_escaped}</textarea>
+  </div>
+</div>
+<div class="controls">
+  <button class="btn btn-nav" onclick="navigateTo({idx - 1})">
+    &larr; Prev<span class="shortcut">Left / P</span></button>
+  <button class="btn btn-save" onclick="saveText()">
+    Save<span class="shortcut">Ctrl+S</span></button>
+  <button class="btn btn-clear" onclick="document.getElementById('transcription').value=''">
+    Clear</button>
+  <button class="btn btn-nav" onclick="navigateTo({idx + 1})">
+    Next &rarr;<span class="shortcut">Right / N</span></button>
+</div>
+<div id="toast" class="toast"></div>
+<script>{js}</script>
+</body></html>"""
+
+
+class OCRAnnotationHandler(SimpleHTTPRequestHandler):
+    """HTTP handler for OCR text annotation."""
+
+    def __init__(self, *args, state=None, **kwargs):
+        self.state = state
+        super().__init__(*args, **kwargs)
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):
+        parsed = urlparse(self.path)
+        params = parse_qs(parsed.query)
+
+        routes = {
+            "/": self._handle_annotate,
+            "/annotate": self._handle_annotate,
+            "/image": self._handle_image,
+        }
+        handler = routes.get(parsed.path)
+        if handler:
+            handler(params)
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        parsed = urlparse(self.path)
+        if parsed.path == "/save":
+            self._handle_save()
+        else:
+            self.send_error(404)
+
+    def _handle_annotate(self, params):
+        idx = int(params.get("idx", ["0"])[0])
+        idx = max(0, min(idx, len(self.state["images"]) - 1))
+
+        image_path = self.state["images"][idx]
+        filename = image_path.name
+        subfolder = _get_subfolder(image_path, self.state["images_root"])
+
+        existing = next(
+            (
+                a
+                for a in self.state["annotations"]
+                if a["filename"] == filename and a.get("subfolder") == subfolder
+            ),
+            None,
+        )
+        if existing:
+            initial_text = existing["text"]
+        else:
+            initial_text = _read_inference(image_path, self.state["inference_ext"])
+
+        html = _build_annotate_html(
+            filename,
+            subfolder,
+            idx,
+            len(self.state["images"]),
+            self.state["n_annotated"],
+            initial_text,
+        )
+        self._send_html(html)
+
+    def _handle_image(self, params):
+        idx = int(params.get("idx", ["0"])[0])
+        if idx < 0 or idx >= len(self.state["images"]):
+            self.send_error(404)
+            return
+
+        image_path = self.state["images"][idx]
+        data = image_path.read_bytes()
+        ext = image_path.suffix.lower()
+        content_type = "image/jpeg" if ext in (".jpg", ".jpeg") else "image/png"
+
+        self.send_response(200)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(data)))
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _handle_save(self):
+        length = int(self.headers.get("Content-Length", 0))
+        body = json.loads(self.rfile.read(length))
+
+        idx = body["idx"]
+        text = body["text"].strip()
+
+        image_path = self.state["images"][idx]
+        filename = image_path.name
+        subfolder = _get_subfolder(image_path, self.state["images_root"])
+
+        annotations = self.state["annotations"]
+        existing = next(
+            (
+                a
+                for a in annotations
+                if a["filename"] == filename and a.get("subfolder") == subfolder
+            ),
+            None,
+        )
+
+        if existing:
+            existing["text"] = text
+        else:
+            split = assign_split()
+            annotations.append(
+                {
+                    "filename": filename,
+                    "subfolder": subfolder,
+                    "text": text,
+                    "split": split,
+                }
+            )
+
+        split = next(
+            a["split"]
+            for a in annotations
+            if a["filename"] == filename and a.get("subfolder") == subfolder
+        )
+        dst_images = OCR_DIR / split / "images" / subfolder
+        dst_labels = OCR_DIR / split / "labels" / subfolder
+        dst_images.mkdir(parents=True, exist_ok=True)
+        dst_labels.mkdir(parents=True, exist_ok=True)
+
+        shutil.copy2(image_path, dst_images / filename)
+        label_path = dst_labels / (image_path.stem + ".txt")
+        label_path.write_text(text, encoding="utf-8")
+
+        self.state["n_annotated"] = sum(1 for a in annotations if a.get("text"))
+        save_split_annotations(annotations, OCR_DIR)
+
+        self._send_json({"ok": True})
+
+    def _send_html(self, html):
+        data = html.encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+    def _send_json(self, obj):
+        data = json.dumps(obj).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(data)))
+        self.end_headers()
+        self.wfile.write(data)
+
+
+def annotate(images_dir, inference_ext=".md", import_dir=None, port=8790):
+    """
+    Start the OCR annotation server.
+
+    Args:
+        images_dir: Directory with processed images (document/class/image.jpg)
+        inference_ext: Extension of inference files to pre-fill
+        import_dir: Optional legacy data directory to import first
+        port: Server port
+    """
+    if import_dir:
+        from trocr_handwritten.utils.annotation import import_legacy_annotations
+
+        import_legacy_annotations(import_dir, str(OCR_DIR), logger)
+
+    images_root = Path(images_dir).resolve()
+    images = collect_images_recursive(images_dir)
+    if not images:
+        logger.error(f"No images found in {images_dir}")
+        return
+
+    logger.info(f"Found {len(images)} images in {images_dir}")
+
+    annotations = load_split_annotations(OCR_DIR)
+    n_annotated = sum(1 for a in annotations if a.get("text"))
+    logger.info(f"Already annotated: {n_annotated}")
+
+    state = {
+        "images": images,
+        "images_root": images_root,
+        "annotations": annotations,
+        "n_annotated": n_annotated,
+        "inference_ext": inference_ext,
+    }
+
+    handler = partial(OCRAnnotationHandler, state=state)
+    server = HTTPServer(("127.0.0.1", port), handler)
+
+    url = f"http://127.0.0.1:{port}"
+    logger.info(f"OCR annotation server: {url}")
+    webbrowser.open(url)
+
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        save_split_annotations(state["annotations"], OCR_DIR)
+        logger.info(f"Saved {len(state['annotations'])} annotations")
+
+
+def main():
+    """CLI entry point for OCR annotation."""
+    parser = argparse.ArgumentParser(description="Annotate OCR transcriptions")
+    parser.add_argument("images_dir", type=str, help="Directory with processed images")
+    parser.add_argument("--inference-ext", type=str, default=".md")
+    parser.add_argument(
+        "--import-dir",
+        type=str,
+        default=None,
+        help="Import legacy annotated data first",
+    )
+    parser.add_argument("--port", type=int, default=8790)
+    args = parser.parse_args()
+
+    annotate(
+        images_dir=args.images_dir,
+        inference_ext=args.inference_ext,
+        import_dir=args.import_dir,
+        port=args.port,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/trocr_handwritten/llm/metrics.py
+++ b/trocr_handwritten/llm/metrics.py
@@ -1,0 +1,200 @@
+import argparse
+from collections import defaultdict
+from pathlib import Path
+from statistics import mean, median, stdev
+
+import evaluate
+import jiwer
+
+from trocr_handwritten.utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _collect_pairs(predictions_dir, labels_dir, pred_ext=".md", label_ext=".txt"):
+    """
+    Match prediction files with label files by stem name, recursively.
+    Preserves subfolder structure for per-class metrics.
+
+    Args:
+        predictions_dir: Directory with prediction files (e.g. .md)
+        labels_dir: Directory with reference label files (e.g. .txt)
+        pred_ext: Extension of prediction files
+        label_ext: Extension of label files
+
+    Returns:
+        list: List of (subfolder, stem, prediction_text, reference_text) tuples
+    """
+    pred_path = Path(predictions_dir)
+    label_path = Path(labels_dir)
+
+    label_map = {}
+    for f in label_path.rglob(f"*{label_ext}"):
+        rel = f.relative_to(label_path)
+        subfolder = str(rel.parent) if rel.parent != Path(".") else ""
+        label_map[(subfolder, f.stem)] = f
+
+    pairs = []
+    for f in sorted(pred_path.rglob(f"*{pred_ext}")):
+        rel = f.relative_to(pred_path)
+        subfolder = str(rel.parent) if rel.parent != Path(".") else ""
+        key = (subfolder, f.stem)
+        if key in label_map:
+            pred_text = f.read_text(encoding="utf-8").strip()
+            ref_text = label_map[key].read_text(encoding="utf-8").strip()
+            if pred_text and ref_text:
+                pairs.append((subfolder, f.stem, pred_text, ref_text))
+
+    return pairs
+
+
+def _levenshtein_distance(ref, hyp):
+    """
+    Compute character-level Levenshtein distance.
+
+    Args:
+        ref: Reference string
+        hyp: Hypothesis string
+
+    Returns:
+        int: Edit distance
+    """
+    measures = jiwer.process_characters(ref, hyp)
+    return measures.substitutions + measures.insertions + measures.deletions
+
+
+def compute_metrics(pairs):
+    """
+    Compute OCR metrics from prediction/reference pairs.
+
+    Args:
+        pairs: List of (subfolder, stem, prediction_text, reference_text)
+
+    Returns:
+        dict: Per-subfolder and global metrics
+    """
+    cer_metric = evaluate.load("cer")
+    wer_metric = evaluate.load("wer")
+
+    per_item = []
+    by_subfolder = defaultdict(list)
+
+    for subfolder, stem, prediction, reference in pairs:
+        item_cer = cer_metric.compute(predictions=[prediction], references=[reference])
+        item_wer = wer_metric.compute(predictions=[prediction], references=[reference])
+        item_lev = _levenshtein_distance(reference, prediction)
+        item_exact = 1.0 if prediction == reference else 0.0
+
+        item = {
+            "filename": stem,
+            "subfolder": subfolder,
+            "cer": item_cer,
+            "wer": item_wer,
+            "levenshtein": item_lev,
+            "exact_match": item_exact,
+        }
+        per_item.append(item)
+        by_subfolder[subfolder].append(item)
+
+    results = {"per_item": per_item, "by_subfolder": {}, "global": {}}
+
+    for subfolder, items in sorted(by_subfolder.items()):
+        cers = [i["cer"] for i in items]
+        wers = [i["wer"] for i in items]
+        levs = [i["levenshtein"] for i in items]
+        exacts = [i["exact_match"] for i in items]
+
+        results["by_subfolder"][subfolder] = {
+            "n": len(items),
+            "cer_mean": mean(cers),
+            "cer_median": median(cers),
+            "cer_std": stdev(cers) if len(cers) > 1 else 0.0,
+            "wer_mean": mean(wers),
+            "wer_median": median(wers),
+            "lev_mean": mean(levs),
+            "exact_pct": mean(exacts) * 100,
+        }
+
+    if per_item:
+        all_cers = [i["cer"] for i in per_item]
+        all_wers = [i["wer"] for i in per_item]
+        all_levs = [i["levenshtein"] for i in per_item]
+        all_exacts = [i["exact_match"] for i in per_item]
+
+        results["global"] = {
+            "n": len(per_item),
+            "cer_mean": mean(all_cers),
+            "cer_median": median(all_cers),
+            "cer_std": stdev(all_cers) if len(all_cers) > 1 else 0.0,
+            "wer_mean": mean(all_wers),
+            "wer_median": median(all_wers),
+            "lev_mean": mean(all_levs),
+            "exact_pct": mean(all_exacts) * 100,
+        }
+
+    return results
+
+
+def log_metrics(results, logger):
+    """
+    Log metrics table to logger.
+
+    Args:
+        results: Output from compute_metrics
+        logger: Logger instance
+    """
+    header = (
+        f"{'Subfolder':>15}  {'CER':>7} {'WER':>7} {'Lev':>7} {'Exact%':>7} {'N':>5}"
+    )
+    logger.info(header)
+    logger.info("-" * 55)
+
+    for subfolder, m in results["by_subfolder"].items():
+        name = subfolder if subfolder else "(root)"
+        logger.info(
+            f"{name:>15}  {m['cer_mean']:>7.4f} {m['wer_mean']:>7.4f} "
+            f"{m['lev_mean']:>7.1f} {m['exact_pct']:>6.1f}% {m['n']:>5}"
+        )
+
+    if results["global"]:
+        g = results["global"]
+        logger.info("-" * 55)
+        logger.info(
+            f"{'ALL':>15}  {g['cer_mean']:>7.4f} {g['wer_mean']:>7.4f} "
+            f"{g['lev_mean']:>7.1f} {g['exact_pct']:>6.1f}% {g['n']:>5}"
+        )
+
+
+def main():
+    """CLI entry point for OCR metrics."""
+    parser = argparse.ArgumentParser(
+        description="Compute OCR metrics: predictions vs labels"
+    )
+    parser.add_argument(
+        "--predictions",
+        type=str,
+        required=True,
+        help="Directory with prediction files (e.g. data/ocr/test/images with .md files)",
+    )
+    parser.add_argument(
+        "--labels",
+        type=str,
+        required=True,
+        help="Directory with reference label files (e.g. data/ocr/test/labels with .txt files)",
+    )
+    parser.add_argument("--pred-ext", type=str, default=".md")
+    parser.add_argument("--label-ext", type=str, default=".txt")
+    args = parser.parse_args()
+
+    pairs = _collect_pairs(args.predictions, args.labels, args.pred_ext, args.label_ext)
+    if not pairs:
+        logger.error("No matching prediction/label pairs found")
+        return
+
+    logger.info(f"Found {len(pairs)} prediction/label pairs")
+    results = compute_metrics(pairs)
+    log_metrics(results, logger)
+
+
+if __name__ == "__main__":
+    main()

--- a/trocr_handwritten/parse/annotate.py
+++ b/trocr_handwritten/parse/annotate.py
@@ -1,7 +1,5 @@
 import argparse
-import colorsys
 import json
-import random
 import webbrowser
 from functools import partial
 from http.server import HTTPServer, SimpleHTTPRequestHandler
@@ -10,80 +8,28 @@ from urllib.parse import parse_qs, urlparse
 
 from trocr_handwritten.parse.settings import CLASS_NAMES, CLASS_NAMES_LIST
 from trocr_handwritten.parse.utils import _load_model
+from trocr_handwritten.utils.annotation import (
+    assign_split,
+    generate_colors,
+    collect_images,
+    load_split_annotations,
+    save_split_annotations,
+)
 from trocr_handwritten.utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
 LAYOUT_DIR = Path("data/layout")
-SPLIT_WEIGHTS = {"train": 0.7, "test": 0.2, "dev": 0.1}
-SPLITS = list(SPLIT_WEIGHTS.keys())
-
-
-def _generate_colors(n):
-    """
-    Generate n visually distinct colors using HSV spacing.
-
-    Args:
-        n: Number of colors to generate
-
-    Returns:
-        list: List of hex color strings
-    """
-    colors = []
-    for i in range(n):
-        hue = i / n
-        r, g, b = colorsys.hsv_to_rgb(hue, 0.75, 0.95)
-        colors.append(f"#{int(r*255):02x}{int(g*255):02x}{int(b*255):02x}")
-    return colors
-
-
-def _assign_split():
-    """Randomly assign a split based on SPLIT_WEIGHTS (train=0.7, test=0.2, dev=0.1)."""
-    r = random.random()
-    cumulative = 0.0
-    for split, weight in SPLIT_WEIGHTS.items():
-        cumulative += weight
-        if r < cumulative:
-            return split
-    return "train"
 
 
 def _load_annotations():
-    """Load existing annotations from all split JSON files into a single list."""
-    all_annotations = []
-    for split in SPLITS:
-        path = LAYOUT_DIR / split / "annotations.json"
-        if path.exists():
-            with open(path, encoding="utf-8") as f:
-                entries = json.load(f)
-                for entry in entries:
-                    entry["split"] = split
-                all_annotations.extend(entries)
-    return all_annotations
+    """Load existing layout annotations."""
+    return load_split_annotations(LAYOUT_DIR)
 
 
 def _save_annotations(annotations):
-    """Save annotations to per-split JSON files."""
-    by_split = {s: [] for s in SPLITS}
-    for a in annotations:
-        split = a.get("split", "train")
-        by_split[split].append(a)
-
-    for split, entries in by_split.items():
-        split_dir = LAYOUT_DIR / split
-        split_dir.mkdir(parents=True, exist_ok=True)
-        path = split_dir / "annotations.json"
-        with open(path, "w", encoding="utf-8") as f:
-            json.dump(entries, f, indent=2, ensure_ascii=False)
-
-
-def _collect_images(images_dir):
-    """Collect all image files from a directory."""
-    extensions = ("*.jpg", "*.jpeg", "*.png")
-    images = []
-    for ext in extensions:
-        images.extend(Path(images_dir).glob(ext))
-    return sorted(images)
+    """Save layout annotations."""
+    save_split_annotations(annotations, LAYOUT_DIR)
 
 
 def _prefill_image(image_path, model):
@@ -464,7 +410,7 @@ def _build_annotate_html(
 ):
     """Build the annotation page HTML."""
     classes_dict = {int(k): v for k, v in CLASS_NAMES.items()}
-    colors = _generate_colors(len(CLASS_NAMES))
+    colors = generate_colors(len(CLASS_NAMES))
     colors_dict = {i: colors[i] for i in range(len(CLASS_NAMES))}
 
     boxes_json = json.dumps(initial_boxes)
@@ -651,7 +597,7 @@ class AnnotationHandler(SimpleHTTPRequestHandler):
                     "image_width": img_w,
                     "image_height": img_h,
                     "boxes": boxes,
-                    "split": _assign_split(),
+                    "split": assign_split(),
                 }
             )
 
@@ -679,7 +625,7 @@ class AnnotationHandler(SimpleHTTPRequestHandler):
 
 def annotate(images_dir, prefill=False, model_path=None, port=8789):
     """Start the annotation server."""
-    images = _collect_images(images_dir)
+    images = collect_images(images_dir)
     if not images:
         logger.error(f"No images found in {images_dir}")
         return

--- a/trocr_handwritten/utils/annotation.py
+++ b/trocr_handwritten/utils/annotation.py
@@ -4,7 +4,6 @@ import random
 import shutil
 from pathlib import Path
 
-
 SPLIT_WEIGHTS = {"train": 0.7, "test": 0.2, "dev": 0.1}
 SPLITS = list(SPLIT_WEIGHTS.keys())
 

--- a/trocr_handwritten/utils/annotation.py
+++ b/trocr_handwritten/utils/annotation.py
@@ -1,0 +1,229 @@
+import colorsys
+import json
+import random
+import shutil
+from pathlib import Path
+
+
+SPLIT_WEIGHTS = {"train": 0.7, "test": 0.2, "dev": 0.1}
+SPLITS = list(SPLIT_WEIGHTS.keys())
+
+
+def assign_split():
+    """Randomly assign a split based on SPLIT_WEIGHTS (train=0.7, test=0.2, dev=0.1)."""
+    r = random.random()
+    cumulative = 0.0
+    for split, weight in SPLIT_WEIGHTS.items():
+        cumulative += weight
+        if r < cumulative:
+            return split
+    return "train"
+
+
+def generate_colors(n):
+    """
+    Generate n visually distinct colors using HSV spacing.
+
+    Args:
+        n: Number of colors to generate
+
+    Returns:
+        list: List of hex color strings
+    """
+    colors = []
+    for i in range(n):
+        hue = i / n
+        r, g, b = colorsys.hsv_to_rgb(hue, 0.75, 0.95)
+        colors.append(f"#{int(r * 255):02x}{int(g * 255):02x}{int(b * 255):02x}")
+    return colors
+
+
+def load_split_annotations(base_dir):
+    """
+    Load annotations from all split JSON files into a single list.
+
+    Args:
+        base_dir: Root directory containing train/test/dev subdirectories
+
+    Returns:
+        list: All annotations with 'split' field added
+    """
+    all_annotations = []
+    base = Path(base_dir)
+    for split in SPLITS:
+        path = base / split / "annotations.json"
+        if path.exists():
+            with open(path, encoding="utf-8") as f:
+                entries = json.load(f)
+                for entry in entries:
+                    entry["split"] = split
+                all_annotations.extend(entries)
+    return all_annotations
+
+
+def save_split_annotations(annotations, base_dir):
+    """
+    Save annotations to per-split JSON files.
+
+    Args:
+        annotations: List of annotation dicts, each with a 'split' field
+        base_dir: Root directory for splits
+    """
+    base = Path(base_dir)
+    by_split = {s: [] for s in SPLITS}
+    for a in annotations:
+        split = a.get("split", "train")
+        by_split[split].append(a)
+
+    for split, entries in by_split.items():
+        split_dir = base / split
+        split_dir.mkdir(parents=True, exist_ok=True)
+        path = split_dir / "annotations.json"
+        with open(path, "w", encoding="utf-8") as f:
+            json.dump(entries, f, indent=2, ensure_ascii=False)
+
+
+def collect_images(images_dir):
+    """
+    Collect all image files from a directory.
+
+    Args:
+        images_dir: Directory to search
+
+    Returns:
+        list: Sorted list of Path objects
+    """
+    extensions = ("*.jpg", "*.jpeg", "*.png")
+    images = []
+    for ext in extensions:
+        images.extend(Path(images_dir).glob(ext))
+    return sorted(images)
+
+
+def collect_images_recursive(images_dir):
+    """
+    Collect all image files recursively from a directory (resolved absolute paths).
+
+    Args:
+        images_dir: Root directory to search
+
+    Returns:
+        list: Sorted list of resolved Path objects
+    """
+    extensions = ("*.jpg", "*.jpeg", "*.png")
+    images = []
+    for ext in extensions:
+        images.extend(p.resolve() for p in Path(images_dir).rglob(ext))
+    return sorted(images)
+
+
+def import_legacy_annotations(input_dir, output_dir, logger):
+    """
+    Import annotated data from legacy format ({subfolder}/images/*.jpg + label/*.txt)
+    into the new split structure (data/ocr/{split}/images/{subfolder}/ + labels/).
+
+    Args:
+        input_dir: Directory with annotated data (subfolders with images/ and label/)
+        output_dir: Output directory (e.g. data/ocr)
+        logger: Logger instance
+    """
+    input_path = Path(input_dir)
+    output_path = Path(output_dir)
+
+    annotations = {s: [] for s in SPLITS}
+    counts = {s: 0 for s in SPLITS}
+
+    subfolders = [
+        d
+        for d in sorted(input_path.iterdir())
+        if d.is_dir() and (d / "images").exists()
+    ]
+
+    if not subfolders:
+        logger.error(f"No subfolders with images/ found in {input_dir}")
+        return
+
+    random.seed(42)
+
+    for subfolder in subfolders:
+        subfolder_name = subfolder.name
+        images_dir = subfolder / "images"
+        labels_dir = subfolder / "label"
+
+        if not labels_dir.exists():
+            logger.warning(f"No label/ directory in {subfolder}, skipping")
+            continue
+
+        image_files = collect_images(images_dir)
+
+        for image_path in image_files:
+            label_path = labels_dir / (image_path.stem + ".txt")
+            if not label_path.exists():
+                continue
+
+            text = label_path.read_text(encoding="utf-8").strip()
+            if not text:
+                continue
+
+            split = assign_split()
+
+            dst_images = output_path / split / "images" / subfolder_name
+            dst_labels = output_path / split / "labels" / subfolder_name
+            dst_images.mkdir(parents=True, exist_ok=True)
+            dst_labels.mkdir(parents=True, exist_ok=True)
+
+            shutil.copy2(image_path, dst_images / image_path.name)
+            shutil.copy2(label_path, dst_labels / (image_path.stem + ".txt"))
+
+            annotations[split].append(
+                {
+                    "filename": image_path.name,
+                    "subfolder": subfolder_name,
+                    "text": text,
+                }
+            )
+            counts[split] += 1
+
+    for split in SPLITS:
+        if not annotations[split]:
+            continue
+        split_dir = output_path / split
+        split_dir.mkdir(parents=True, exist_ok=True)
+        ann_path = split_dir / "annotations.json"
+        with open(ann_path, "w", encoding="utf-8") as f:
+            json.dump(annotations[split], f, indent=2, ensure_ascii=False)
+
+    total = sum(counts.values())
+    logger.info(f"Imported {total} samples from {input_dir}")
+    for split in SPLITS:
+        logger.info(f"  {split}: {counts[split]}")
+
+
+ANNOTATE_BASE_CSS = """
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+       background: #1a1a2e; color: #eee; height: 100vh; display: flex; flex-direction: column;
+       overflow: hidden; user-select: none; }
+.header { background: #16213e; padding: 0.6rem 1.5rem; display: flex;
+          align-items: center; justify-content: space-between; flex-shrink: 0; }
+.header h1 { font-size: 0.95rem; font-weight: 500; color: #a8b2d1; }
+.header-right { display: flex; align-items: center; gap: 1rem; }
+.progress { font-size: 0.8rem; color: #8892b0; }
+.stats { font-size: 0.75rem; color: #64ffda; }
+.controls { background: #0f1729; padding: 0.5rem 1rem; display: flex;
+            justify-content: center; gap: 0.6rem; flex-shrink: 0; }
+.btn { padding: 0.5rem 1.5rem; border: none; border-radius: 5px; font-size: 0.85rem;
+       font-weight: 600; cursor: pointer; transition: all 0.1s; }
+.btn-nav { background: #495670; color: #ccd6f6; }
+.btn-nav:hover { background: #5a6a8a; }
+.btn-save { background: #64ffda; color: #0a192f; }
+.btn-save:hover { background: #4cd9b0; }
+.btn-clear { background: #f07178; color: #0a192f; }
+.btn-clear:hover { background: #d45d63; }
+.shortcut { font-size: 0.65rem; color: #8892b0; display: block; margin-top: 0.1rem; }
+.toast { position: fixed; top: 1rem; right: 1rem; padding: 0.6rem 1.2rem;
+         background: #64ffda; color: #0a192f; border-radius: 5px; font-weight: 600;
+         font-size: 0.85rem; opacity: 0; transition: opacity 0.3s; z-index: 999;
+         pointer-events: none; }
+.toast.show { opacity: 1; }
+"""


### PR DESCRIPTION
## Summary
- Extract shared annotation utils to `utils/annotation.py` (splits, colors, file I/O)
- Add OCR transcription annotation tool (`llm/annotate.py`) with pre-fill from `.md` inferences
- Add OCR metrics (`llm/metrics.py`): CER, WER, Levenshtein, exact match per subfolder
- Already annotated images are skipped in the annotation flow

## Usage
```bash
# Annotate
python -m trocr_handwritten.llm.annotate data/processed/images/

# Apply OCR on test set
python -m trocr_handwritten.llm.ocr --input_dir data/ocr/test/images --pattern "*/*.jpg"

# Compute metrics
python -m trocr_handwritten.llm.metrics --predictions data/ocr/test/images --labels data/ocr/test/labels
```