### PR TITLE
feat(llm): add self-hosted vLLM provider with H100 deployment

### DIFF
--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -28,7 +28,7 @@ class TestLLMSettings:
 
     def test_max_tokens_default(self):
         settings = LLMSettings()
-        assert settings.max_tokens == 128000
+        assert settings.max_tokens == 16000
 
     def test_custom_settings(self):
         settings = LLMSettings(

--- a/trocr_handwritten/llm/deployment/download_models.sh
+++ b/trocr_handwritten/llm/deployment/download_models.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Pre-download the three target models into the HF cache so that the first
+# vLLM startup is instant. Requires HF_TOKEN to be exported in the shell
+# for gated repos (Gemma).
+
+: "${HF_HOME:=/workspace/hf_cache}"
+export HF_HOME
+export HF_HUB_ENABLE_HF_TRANSFER=1
+
+MODELS=(
+    "google/gemma-4-26B-A4B-it"
+    "Qwen/Qwen3.6-35B-A3B"
+    "Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR"
+)
+
+if [ -z "${HF_TOKEN:-}" ]; then
+    echo "Warning: HF_TOKEN is not set. Gated models (e.g. Gemma) will fail to download."
+fi
+
+for model in "${MODELS[@]}"; do
+    echo ""
+    echo "==> Downloading $model"
+    hf download "$model" \
+        --token "${HF_TOKEN:-}" \
+        --cache-dir "$HF_HOME"
+done
+
+echo ""
+echo "All models downloaded to $HF_HOME"
+du -sh "$HF_HOME"

--- a/trocr_handwritten/llm/deployment/serve_vllm.sh
+++ b/trocr_handwritten/llm/deployment/serve_vllm.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Launch a vLLM OpenAI-compatible server for a single model.
+# Usage:
+#   bash serve_vllm.sh <hf_repo_id> [port]
+#
+# Examples:
+#   bash serve_vllm.sh google/gemma-4-26B-A4B-it
+#   bash serve_vllm.sh Qwen/Qwen3.6-35B-A3B 8000
+#   bash serve_vllm.sh Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR
+
+if [ $# -lt 1 ]; then
+    echo "Usage: $0 <hf_repo_id> [port]"
+    exit 1
+fi
+
+MODEL="$1"
+PORT="${2:-8000}"
+
+: "${HF_HOME:=/workspace/hf_cache}"
+export HF_HOME
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+
+if [ -f /workspace/.venv/bin/activate ]; then
+    # shellcheck disable=SC1091
+    source /workspace/.venv/bin/activate
+fi
+
+# Vision-Language models need image input slots. Non-VL models do not.
+# Defaults to enabling multimodal; export SERVE_TEXT_ONLY=1 to disable for
+# pure-text models.
+EXTRA_ARGS=()
+if [ -z "${SERVE_TEXT_ONLY:-}" ]; then
+    EXTRA_ARGS+=(--limit-mm-per-prompt '{"image": 4}')
+fi
+
+# MoE models benefit from enforce-eager off and longer ctx; defaults kept simple.
+SERVED_NAME="$(basename "$MODEL")"
+
+echo "==> Serving $MODEL as '$SERVED_NAME' on :$PORT"
+echo "==> OpenAI endpoint will be: http://<host>:$PORT/v1"
+
+vllm serve "$MODEL" \
+    --host 0.0.0.0 \
+    --port "$PORT" \
+    --served-model-name "$SERVED_NAME" \
+    --download-dir "$HF_HOME" \
+    --dtype bfloat16 \
+    --max-model-len 32768 \
+    --gpu-memory-utilization 0.90 \
+    --trust-remote-code \
+    "${EXTRA_ARGS[@]}"

--- a/trocr_handwritten/llm/deployment/setup_h100.sh
+++ b/trocr_handwritten/llm/deployment/setup_h100.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Provision a fresh Scaleway H100 instance with everything needed to run vLLM.
+# Idempotent: safe to re-run.
+
+: "${HF_HOME:=/workspace/hf_cache}"
+export HF_HOME
+
+echo "==> System packages"
+sudo apt-get update -y
+sudo apt-get install -y --no-install-recommends \
+    build-essential git curl ca-certificates tmux htop nvtop \
+    cuda-toolkit-12-8
+
+echo "==> NVIDIA driver / CUDA sanity check"
+nvidia-smi
+export CUDA_HOME=/usr/local/cuda-12.8
+export PATH="$CUDA_HOME/bin:$PATH"
+if command -v nvcc >/dev/null 2>&1; then
+    nvcc --version
+else
+    echo "Warning: nvcc not found after install. FlashInfer JIT kernels will fail."
+fi
+
+echo "==> uv"
+if ! command -v uv >/dev/null 2>&1; then
+    curl -LsSf https://astral.sh/uv/install.sh | sh
+    export PATH="$HOME/.local/bin:$PATH"
+fi
+
+echo "==> Python venv + vLLM"
+cd /workspace
+if [ ! -d .venv ]; then
+    uv venv --python 3.12 .venv
+fi
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+uv pip install --upgrade pip
+uv pip install "vllm>=0.7.0" "huggingface_hub[cli]" "hf_transfer"
+
+echo "==> HuggingFace cache dir: $HF_HOME"
+mkdir -p "$HF_HOME"
+
+echo ""
+echo "Setup complete."
+echo "Next steps:"
+echo "  1. export HF_TOKEN=hf_xxx     # needed for gated models (Gemma)"
+echo "  2. bash download_models.sh"
+echo "  3. bash serve_vllm.sh <model_id>"

--- a/trocr_handwritten/llm/factory.py
+++ b/trocr_handwritten/llm/factory.py
@@ -3,11 +3,13 @@ from trocr_handwritten.llm.settings import LLMSettings
 from trocr_handwritten.llm.providers.openai import OpenAIProvider
 from trocr_handwritten.llm.providers.gemini import GeminiProvider
 from trocr_handwritten.llm.providers.mistral import MistralProvider
+from trocr_handwritten.llm.providers.vllm import VLLMProvider
 
 PROVIDERS = {
     "openai": OpenAIProvider,
     "gemini": GeminiProvider,
     "mistral": MistralProvider,
+    "vllm": VLLMProvider,
 }
 
 

--- a/trocr_handwritten/llm/ocr.py
+++ b/trocr_handwritten/llm/ocr.py
@@ -173,8 +173,21 @@ def main():
         "--provider",
         type=str,
         default="gemini",
-        choices=["openai", "gemini", "mistral"],
+        choices=["openai", "gemini", "mistral", "vllm"],
         help="LLM provider to use",
+    )
+    parser.add_argument(
+        "--vllm_base_url",
+        type=str,
+        default=None,
+        help="Base URL of the vLLM server (overrides VLLM_BASE_URL env var). "
+        "Required when --provider=vllm.",
+    )
+    parser.add_argument(
+        "--vllm_api_key",
+        type=str,
+        default=None,
+        help="API key for the vLLM server (overrides VLLM_API_KEY env var).",
     )
     parser.add_argument(
         "--model",
@@ -208,6 +221,23 @@ def main():
         choices=["low", "medium", "high"],
         help="Reasoning effort for Gemini thinking models",
     )
+    parser.add_argument(
+        "--max_tokens",
+        type=int,
+        default=None,
+        help="Max output tokens per call (defaults to LLMSettings.max_tokens).",
+    )
+    parser.add_argument(
+        "--request_timeout",
+        type=float,
+        default=None,
+        help="Per-request HTTP timeout in seconds (defaults to 120).",
+    )
+    parser.add_argument(
+        "--disable_thinking",
+        action="store_true",
+        help="vLLM-only: disable <think> block for Qwen3/Qwen3-Next models.",
+    )
     args = parser.parse_args()
 
     model_defaults = {
@@ -216,14 +246,31 @@ def main():
         "mistral": "mistral-large-latest",
     }
 
+    if args.provider == "vllm" and not args.model:
+        parser.error(
+            "--model is required when --provider=vllm (HF repo id served by vLLM)"
+        )
+
     model_name = args.model or model_defaults.get(args.provider, "gemini-2.0-flash")
 
-    llm_settings = LLMSettings(
-        provider=args.provider,
-        model_name=model_name,
-        prompt_path=args.prompt_path,
-        reasoning_effort=args.reasoning_effort,
-    )
+    llm_kwargs = {
+        "provider": args.provider,
+        "model_name": model_name,
+        "prompt_path": args.prompt_path,
+        "reasoning_effort": args.reasoning_effort,
+    }
+    if args.vllm_base_url:
+        llm_kwargs["vllm_base_url"] = args.vllm_base_url
+    if args.vllm_api_key:
+        llm_kwargs["vllm_api_key"] = args.vllm_api_key
+    if args.max_tokens is not None:
+        llm_kwargs["max_tokens"] = args.max_tokens
+    if args.request_timeout is not None:
+        llm_kwargs["request_timeout"] = args.request_timeout
+    if args.disable_thinking:
+        llm_kwargs["disable_thinking"] = True
+
+    llm_settings = LLMSettings(**llm_kwargs)
 
     ocr_settings = OCRSettings(
         input_dir=args.input_dir,

--- a/trocr_handwritten/llm/providers/vllm.py
+++ b/trocr_handwritten/llm/providers/vllm.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+from typing import Tuple
+
+from openai import OpenAI, AsyncOpenAI
+
+from trocr_handwritten.llm.base import LLMProvider
+from trocr_handwritten.llm.settings import LLMSettings
+
+
+class VLLMProvider(LLMProvider):
+    """Self-hosted vLLM provider using OpenAI-compatible API."""
+
+    def __init__(self, settings: LLMSettings):
+        """
+        Initialize the vLLM provider.
+
+        Args:
+            settings: LLM configuration settings. Requires vllm_base_url.
+        """
+        super().__init__(settings)
+        if not self.settings.vllm_base_url:
+            raise ValueError("vllm_base_url must be set when using the vllm provider")
+        self._init_client()
+
+    def _init_client(self) -> None:
+        """Initialize the OpenAI-compatible client pointing at the vLLM server."""
+        api_key = self.settings.vllm_api_key or "EMPTY"
+        self.client = OpenAI(
+            api_key=api_key,
+            base_url=self.settings.vllm_base_url,
+            timeout=self.settings.request_timeout,
+        )
+        self.async_client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=self.settings.vllm_base_url,
+            timeout=self.settings.request_timeout,
+        )
+
+    def _build_messages(self, image_path: Path, prompt: str) -> list:
+        """Build the messages payload for the API call."""
+        base64_image = self._encode_image_base64(image_path)
+        mime_type = self._get_mime_type(image_path)
+        return [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": f"data:{mime_type};base64,{base64_image}"},
+                    },
+                ],
+            }
+        ]
+
+    def _build_kwargs(self, model: str, messages: list) -> dict:
+        """Build kwargs for chat.completions.create, including vLLM extras."""
+        kwargs = {
+            "model": model,
+            "messages": messages,
+            "temperature": self.settings.temperature,
+            "max_tokens": self.settings.max_tokens,
+        }
+        if self.settings.disable_thinking:
+            kwargs["extra_body"] = {
+                "chat_template_kwargs": {"enable_thinking": False},
+            }
+        return kwargs
+
+    @staticmethod
+    def _strip_thinking(text: str) -> str:
+        """Remove any <think>...</think> block left by the model."""
+        if not text:
+            return text
+        if "</think>" in text:
+            return text.split("</think>", 1)[1].lstrip("\n ")
+        return text
+
+    def _call_api(self, model: str, messages: list) -> Tuple[str, int, int]:
+        """Make a synchronous API call."""
+        response = self.client.chat.completions.create(
+            **self._build_kwargs(model, messages)
+        )
+        text = self._strip_thinking(response.choices[0].message.content)
+        input_tokens = response.usage.prompt_tokens if response.usage else 0
+        output_tokens = response.usage.completion_tokens if response.usage else 0
+        return text, input_tokens, output_tokens
+
+    async def _call_api_async(self, model: str, messages: list) -> Tuple[str, int, int]:
+        """Make an asynchronous API call."""
+        response = await self.async_client.chat.completions.create(
+            **self._build_kwargs(model, messages)
+        )
+        text = self._strip_thinking(response.choices[0].message.content)
+        input_tokens = response.usage.prompt_tokens if response.usage else 0
+        output_tokens = response.usage.completion_tokens if response.usage else 0
+        return text, input_tokens, output_tokens

--- a/trocr_handwritten/llm/settings.py
+++ b/trocr_handwritten/llm/settings.py
@@ -48,8 +48,17 @@ class LLMSettings(BaseModel):
         description="Temperature for text generation",
     )
     max_tokens: int = Field(
-        default=128000,
+        default=16000,
         description="Maximum number of tokens to generate",
+    )
+    request_timeout: float = Field(
+        default=120.0,
+        description="Per-request HTTP timeout in seconds.",
+    )
+    disable_thinking: bool = Field(
+        default=False,
+        description="For vLLM-served Qwen3/Qwen3-Next models, disable the "
+        "<think>...</think> reasoning block via chat_template_kwargs.",
     )
     prompt_path: str = Field(
         default="config/ocr.prompt",

--- a/trocr_handwritten/llm/settings.py
+++ b/trocr_handwritten/llm/settings.py
@@ -9,7 +9,7 @@ load_dotenv()
 class LLMSettings(BaseModel):
     """Configuration settings for LLM-based OCR."""
 
-    provider: Literal["openai", "gemini", "mistral"] = Field(
+    provider: Literal["openai", "gemini", "mistral", "vllm"] = Field(
         default="gemini",
         description="LLM provider to use for OCR",
     )
@@ -28,6 +28,15 @@ class LLMSettings(BaseModel):
     mistral_api_key: Optional[str] = Field(
         default=os.getenv("MISTRAL_API_KEY"),
         description="Mistral AI API key",
+    )
+    vllm_base_url: Optional[str] = Field(
+        default=os.getenv("VLLM_BASE_URL"),
+        description="Base URL of a self-hosted vLLM OpenAI-compatible server "
+        "(e.g. http://h100.example.com:8000/v1)",
+    )
+    vllm_api_key: Optional[str] = Field(
+        default=os.getenv("VLLM_API_KEY"),
+        description="API key for the vLLM server. Defaults to 'EMPTY' if unset.",
     )
     reasoning_effort: Optional[str] = Field(
         default=None,

--- a/trocr_handwritten/llm/vllm.md
+++ b/trocr_handwritten/llm/vllm.md
@@ -1,204 +1,144 @@
-# Déployer un modèle sur H100 Scaleway avec vLLM
+# Deploy a model on a Scaleway H100 with vLLM
 
-Ce guide déploie un modèle Hugging Face sur une instance H100 Scaleway derrière une API OpenAI-compatible (vLLM), puis le branche au pipeline OCR via le provider `vllm`.
+Serve a Hugging Face model behind an OpenAI-compatible API on a Scaleway H100, then plug it into the OCR pipeline via the `vllm` provider. One model at a time — swap by restarting the script.
 
-Un seul modèle est servi à la fois. Pour en changer, on tue le serveur et on relance le script avec un autre repo id.
+## Target models
 
-## Modèles cibles
-
-| Repo HF | Type | Gated |
+| HF repo | Type | Gated |
 |---|---|---|
-| `google/gemma-4-26B-A4B-it` | Texte MoE | Oui (HF token requis) |
-| `Qwen/Qwen3.6-35B-A3B` | Texte MoE | Non |
-| `Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR` | Vision-Language | Non |
+| `google/gemma-4-26B-A4B-it` | Text MoE | Yes (HF token) |
+| `Qwen/Qwen3.6-35B-A3B` | VL MoE (Qwen3-Next) | No |
+| `Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR` | Vision-Language | No |
 
-## 1. Provisionner l'instance
+## 1. Provision the instance
 
-Dans la console Scaleway, créer une instance **H100-1-80G** (80 GB VRAM, Ubuntu 22.04). La clé SSH ajoutée au compte est propagée automatiquement.
-
-Se connecter :
+Create an **H100-1-80G** (Ubuntu 22.04+) on Scaleway. Verify your SSH key is attached to the account, then:
 
 ```bash
-ssh root@<IP_PUBLIQUE>
-```
-
-Créer un workspace persistant :
-
-```bash
+ssh root@<PUBLIC_IP>
 mkdir -p /workspace && cd /workspace
 ```
 
-## 2. Récupérer les scripts
+## 2. Copy scripts and install
 
-Deux options.
-
-**Option A — cloner le repo complet :**
+From your laptop:
 
 ```bash
-git clone https://github.com/handwrittenOCR/trocr_handwritten.git
-cd trocr_handwritten/trocr_handwritten/llm/deployment
+scp trocr_handwritten/llm/deployment/*.sh root@<PUBLIC_IP>:/workspace/
 ```
 
-**Option B — copier juste les 3 scripts depuis ta machine :**
-
-```bash
-# Depuis ton Mac
-scp trocr_handwritten/llm/deployment/*.sh root@<IP_PUBLIQUE>:/workspace/
-```
-
-## 3. Installer l'environnement
+On the H100:
 
 ```bash
 bash setup_h100.sh
 ```
 
-Ce script :
-- installe les paquets système de base (`build-essential`, `tmux`, `nvtop`...)
-- vérifie la présence du driver CUDA via `nvidia-smi`
-- installe `uv`
-- crée un venv Python 3.12 dans `/workspace/.venv`
-- installe `vllm`, `huggingface_hub[cli]`, `hf_transfer`
+Installs `uv`, a Python 3.12 venv in `/workspace/.venv`, `vllm`, `huggingface_hub`, and `cuda-toolkit-12-8` (required by FlashInfer JIT for Qwen3-Next).
 
-Durée : ~3-5 minutes.
+## 3. Use `/scratch` for model weights
 
-## 4. Télécharger les modèles
+The root disk (~110 GB) is too small for the three models (~130 GB total). Scaleway H100 instances ship with a 2.7 TB NVMe mounted at `/scratch`:
 
-Gemma nécessite un token HF (modèle gated). Demander l'accès sur la page HF, puis :
+```bash
+mkdir -p /scratch/hf_cache
+rm -rf /workspace/hf_cache
+ln -s /scratch/hf_cache /workspace/hf_cache
+```
+
+## 4. Download models
+
+Gemma requires an HF token (gated):
 
 ```bash
 export HF_TOKEN=hf_xxxxxxxxxxxxxxxx
 bash download_models.sh
 ```
 
-Les poids sont cachés dans `/workspace/hf_cache`. Les trois modèles pèsent environ 110-130 GB au total.
+## 5. Serve one model
 
-## 5. Servir un modèle
-
-Le script prend le repo id en argument et un port optionnel (8000 par défaut) :
+Use `tmux` so the server survives SSH disconnects:
 
 ```bash
-# Dans un tmux pour garder le serveur vivant après déconnexion SSH
 tmux new -s vllm
-
-bash serve_vllm.sh Qwen/Qwen3.6-35B-A3B
-# ou
-bash serve_vllm.sh google/gemma-4-26B-A4B-it
-# ou (vision)
-bash serve_vllm.sh Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR
+bash serve_vllm.sh Qwen/Qwen3.6-35B-A3B   # or any of the 3 repos
+# Ctrl+b then d to detach
 ```
 
-Détacher tmux avec `Ctrl+b` puis `d`. Revenir avec `tmux attach -t vllm`.
-
-Le serveur écoute sur `http://0.0.0.0:8000/v1`. Le nom exposé côté API (`--served-model-name`) est la dernière portion du repo, ex : `Qwen3.6-35B-A3B`.
-
-## 6. Exposer le port côté client
-
-Deux options.
-
-**Tunnel SSH (recommandé, pas besoin d'ouvrir de port) :**
+The server listens on `http://0.0.0.0:8000/v1` and exposes the model under the last segment of the repo id (e.g. `Qwen3.6-35B-A3B`). Confirm with:
 
 ```bash
-# Depuis ton Mac, dans un autre terminal
-ssh -N -L 8000:localhost:8000 root@<IP_PUBLIQUE>
+curl http://localhost:8000/v1/models
 ```
 
-Le serveur est alors joignable sur `http://localhost:8000/v1` depuis ton Mac.
-
-**IP publique (plus simple mais à sécuriser) :**
-
-Ouvrir le port 8000 dans le security group Scaleway. L'endpoint devient `http://<IP_PUBLIQUE>:8000/v1`. Ajouter `--api-key <token>` à `vllm serve` et passer le token côté client via `VLLM_API_KEY` pour éviter un endpoint ouvert.
-
-## 7. Configurer le client OCR
-
-Dans le `.env` du projet local :
+## 6. SSH tunnel from your laptop
 
 ```bash
+ssh -N -L 8000:localhost:8000 root@<PUBLIC_IP>
+```
+
+Leave it running.
+
+## 7. Configure the client
+
+Add to `.env`:
+
+```
 VLLM_BASE_URL=http://localhost:8000/v1
-VLLM_API_KEY=EMPTY     # ou le token si --api-key utilisé côté serveur
+VLLM_API_KEY=EMPTY
 ```
 
-Vérifier que le serveur répond :
-
-```bash
-curl $VLLM_BASE_URL/models
-```
-
-## 8. Lancer l'OCR
-
-Le paramètre `--model` est le nom exposé par vLLM (`--served-model-name`), pas forcément le repo id complet.
+## 8. Run OCR
 
 ```bash
 uv run python -m trocr_handwritten.llm.ocr \
     --provider vllm \
     --model Qwen3.6-35B-A3B \
-    --input_dir data/processed/images \
-    --pattern "*/*/*.jpg" \
-    --output_dir data/ocr/test/predictions/qwen3-35b \
-    --max_concurrent 16
+    --input_dir data/ocr/test/images \
+    --pattern "*/*.jpg" \
+    --output_dir data/ocr/test/predictions/qwen3.6-35b \
+    --max_concurrent 8 \
+    --disable_thinking
 ```
 
-Surcharger l'URL directement en ligne de commande (utile pour pointer vers un autre host sans toucher au `.env`) :
+Flags:
+- `--disable_thinking` strips Qwen3 `<think>…</think>` reasoning blocks (big speedup + cleaner output)
+- `--max_concurrent` — 4–8 for 26–35B, 16–32 for 7B
+- `--request_timeout` — defaults to 120s
+
+## 9. Switch models
 
 ```bash
-uv run python -m trocr_handwritten.llm.ocr \
-    --provider vllm \
-    --model Gemma-4-26B-A4B-it \
-    --vllm_base_url http://localhost:8000/v1 \
-    --input_dir data/processed/images \
-    --output_dir data/ocr/test/predictions/gemma-4-26b
+tmux attach -t vllm
+# Ctrl+C
+bash serve_vllm.sh <another_repo>
 ```
 
-## 9. Changer de modèle
+Weights stay cached in `/scratch/hf_cache`.
+
+## Troubleshooting
+
+**`No space left on device`** — see step 3 (symlink `/workspace/hf_cache` to `/scratch`).
+
+**`Could not find nvcc`** (Qwen3-Next) — install the CUDA toolkit:
 
 ```bash
-# Dans le tmux vllm
-Ctrl+C    # tue le serveur
-bash serve_vllm.sh <autre_modele>
+sudo apt-get install -y cuda-toolkit-12-8
+export CUDA_HOME=/usr/local/cuda-12.8
+export PATH=$CUDA_HOME/bin:$PATH
 ```
 
-Pas besoin de re-télécharger : les poids restent dans `/workspace/hf_cache`.
+**`CUDA out of memory`** — lower `--gpu-memory-utilization` to `0.85` or `--max-model-len` to `16384` in `serve_vllm.sh`.
 
-## Dépannage
+**`max_tokens=... > max_model_len`** — the client default is 16 000; pass `--max_tokens <N>` if needed.
 
-**`No space left on device` pendant `download_models.sh`** — le disque root `/` des instances Scaleway H100 fait ~110 GB, trop peu pour les 3 modèles (~130 GB). Un volume NVMe de ~2.7 TB est monté sur `/scratch`. Basculer le cache HF :
+**Model not found from the client** — check the exact served name via `curl /v1/models` and use it in `--model`.
 
-```bash
-# Nettoyer les downloads partiels sur /
-rm -rf /workspace/hf_cache/models--*<partiel>*
+## Cost
 
-# Déplacer ce qui a déjà été téléchargé
-mkdir -p /scratch/hf_cache
-mv /workspace/hf_cache/* /workspace/hf_cache/.[!.]* /scratch/hf_cache/ 2>/dev/null || true
-
-# Remplacer le dossier par un symlink
-rm -rf /workspace/hf_cache
-ln -s /scratch/hf_cache /workspace/hf_cache
-
-# Vérifier puis relancer
-df -h / /scratch
-bash download_models.sh
-```
-
-Vérifier à l'avance avec `lsblk` : si un `/dev/sdb` ou `/dev/nvme1n1` de plusieurs TB est listé et monté sur `/scratch`, utiliser ce chemin. Si rien n'est monté, le formater et le monter manuellement (`mkfs.ext4` + `mount`).
-
-**`CUDA out of memory` au chargement** — baisser `--gpu-memory-utilization` (dans `serve_vllm.sh`) à `0.85` ou `--max-model-len` à `16384`.
-
-**`Model not found` côté client** — vérifier le nom exact avec `curl $VLLM_BASE_URL/models`. vLLM expose la dernière portion du repo id sauf si `--served-model-name` est override.
-
-**Téléchargement lent** — vérifier que `hf_transfer` est bien installé (`HF_HUB_ENABLE_HF_TRANSFER=1` dans `download_models.sh`). Sur Scaleway la bande passante est généralement > 500 MB/s.
-
-**MoE qui refuse de charger** — ajouter `--enforce-eager` dans `serve_vllm.sh` pour désactiver CUDA graphs si le compile échoue.
-
-**Qwen2.5-VL ne reçoit pas l'image** — le provider envoie déjà `image_url` en base64, géré nativement par vLLM. Si l'image n'est pas prise en compte, vérifier que `--limit-mm-per-prompt image=4` est bien passé (c'est fait automatiquement par `serve_vllm.sh` pour tout repo contenant `VL`).
-
-## Coûts
-
-vLLM étant self-hosted, le coût ne dépend pas des tokens mais du temps d'occupation de l'instance H100. Le `CostTracker` calcule :
+vLLM is self-hosted, so cost is time-based:
 
 ```
 cost_usd = elapsed_hours × VLLM_HOURLY_EUR × EUR_TO_USD
 ```
 
-avec `VLLM_HOURLY_EUR=2.8` et `EUR_TO_USD=1.08` par défaut dans [cost_tracker.py](../utils/cost_tracker.py). Les tokens restent comptés et exposés dans le `summary.json`, mais ne sont pas facturés.
-
-Si tu changes de plan Scaleway, ajuste `VLLM_HOURLY_EUR`. Pour ajouter un nouveau modèle self-hosté, ajoute son nom exposé (celui passé à `--served-model-name`) dans le set `VLLM_MODELS`.
+Defaults (`2.8 €/h`, `1.08 EUR→USD`) live in [cost_tracker.py](../utils/cost_tracker.py). Tokens are still logged in `summary.json` but not billed.

--- a/trocr_handwritten/llm/vllm.md
+++ b/trocr_handwritten/llm/vllm.md
@@ -1,0 +1,204 @@
+# Déployer un modèle sur H100 Scaleway avec vLLM
+
+Ce guide déploie un modèle Hugging Face sur une instance H100 Scaleway derrière une API OpenAI-compatible (vLLM), puis le branche au pipeline OCR via le provider `vllm`.
+
+Un seul modèle est servi à la fois. Pour en changer, on tue le serveur et on relance le script avec un autre repo id.
+
+## Modèles cibles
+
+| Repo HF | Type | Gated |
+|---|---|---|
+| `google/gemma-4-26B-A4B-it` | Texte MoE | Oui (HF token requis) |
+| `Qwen/Qwen3.6-35B-A3B` | Texte MoE | Non |
+| `Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR` | Vision-Language | Non |
+
+## 1. Provisionner l'instance
+
+Dans la console Scaleway, créer une instance **H100-1-80G** (80 GB VRAM, Ubuntu 22.04). La clé SSH ajoutée au compte est propagée automatiquement.
+
+Se connecter :
+
+```bash
+ssh root@<IP_PUBLIQUE>
+```
+
+Créer un workspace persistant :
+
+```bash
+mkdir -p /workspace && cd /workspace
+```
+
+## 2. Récupérer les scripts
+
+Deux options.
+
+**Option A — cloner le repo complet :**
+
+```bash
+git clone https://github.com/handwrittenOCR/trocr_handwritten.git
+cd trocr_handwritten/trocr_handwritten/llm/deployment
+```
+
+**Option B — copier juste les 3 scripts depuis ta machine :**
+
+```bash
+# Depuis ton Mac
+scp trocr_handwritten/llm/deployment/*.sh root@<IP_PUBLIQUE>:/workspace/
+```
+
+## 3. Installer l'environnement
+
+```bash
+bash setup_h100.sh
+```
+
+Ce script :
+- installe les paquets système de base (`build-essential`, `tmux`, `nvtop`...)
+- vérifie la présence du driver CUDA via `nvidia-smi`
+- installe `uv`
+- crée un venv Python 3.12 dans `/workspace/.venv`
+- installe `vllm`, `huggingface_hub[cli]`, `hf_transfer`
+
+Durée : ~3-5 minutes.
+
+## 4. Télécharger les modèles
+
+Gemma nécessite un token HF (modèle gated). Demander l'accès sur la page HF, puis :
+
+```bash
+export HF_TOKEN=hf_xxxxxxxxxxxxxxxx
+bash download_models.sh
+```
+
+Les poids sont cachés dans `/workspace/hf_cache`. Les trois modèles pèsent environ 110-130 GB au total.
+
+## 5. Servir un modèle
+
+Le script prend le repo id en argument et un port optionnel (8000 par défaut) :
+
+```bash
+# Dans un tmux pour garder le serveur vivant après déconnexion SSH
+tmux new -s vllm
+
+bash serve_vllm.sh Qwen/Qwen3.6-35B-A3B
+# ou
+bash serve_vllm.sh google/gemma-4-26B-A4B-it
+# ou (vision)
+bash serve_vllm.sh Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR
+```
+
+Détacher tmux avec `Ctrl+b` puis `d`. Revenir avec `tmux attach -t vllm`.
+
+Le serveur écoute sur `http://0.0.0.0:8000/v1`. Le nom exposé côté API (`--served-model-name`) est la dernière portion du repo, ex : `Qwen3.6-35B-A3B`.
+
+## 6. Exposer le port côté client
+
+Deux options.
+
+**Tunnel SSH (recommandé, pas besoin d'ouvrir de port) :**
+
+```bash
+# Depuis ton Mac, dans un autre terminal
+ssh -N -L 8000:localhost:8000 root@<IP_PUBLIQUE>
+```
+
+Le serveur est alors joignable sur `http://localhost:8000/v1` depuis ton Mac.
+
+**IP publique (plus simple mais à sécuriser) :**
+
+Ouvrir le port 8000 dans le security group Scaleway. L'endpoint devient `http://<IP_PUBLIQUE>:8000/v1`. Ajouter `--api-key <token>` à `vllm serve` et passer le token côté client via `VLLM_API_KEY` pour éviter un endpoint ouvert.
+
+## 7. Configurer le client OCR
+
+Dans le `.env` du projet local :
+
+```bash
+VLLM_BASE_URL=http://localhost:8000/v1
+VLLM_API_KEY=EMPTY     # ou le token si --api-key utilisé côté serveur
+```
+
+Vérifier que le serveur répond :
+
+```bash
+curl $VLLM_BASE_URL/models
+```
+
+## 8. Lancer l'OCR
+
+Le paramètre `--model` est le nom exposé par vLLM (`--served-model-name`), pas forcément le repo id complet.
+
+```bash
+uv run python -m trocr_handwritten.llm.ocr \
+    --provider vllm \
+    --model Qwen3.6-35B-A3B \
+    --input_dir data/processed/images \
+    --pattern "*/*/*.jpg" \
+    --output_dir data/ocr/test/predictions/qwen3-35b \
+    --max_concurrent 16
+```
+
+Surcharger l'URL directement en ligne de commande (utile pour pointer vers un autre host sans toucher au `.env`) :
+
+```bash
+uv run python -m trocr_handwritten.llm.ocr \
+    --provider vllm \
+    --model Gemma-4-26B-A4B-it \
+    --vllm_base_url http://localhost:8000/v1 \
+    --input_dir data/processed/images \
+    --output_dir data/ocr/test/predictions/gemma-4-26b
+```
+
+## 9. Changer de modèle
+
+```bash
+# Dans le tmux vllm
+Ctrl+C    # tue le serveur
+bash serve_vllm.sh <autre_modele>
+```
+
+Pas besoin de re-télécharger : les poids restent dans `/workspace/hf_cache`.
+
+## Dépannage
+
+**`No space left on device` pendant `download_models.sh`** — le disque root `/` des instances Scaleway H100 fait ~110 GB, trop peu pour les 3 modèles (~130 GB). Un volume NVMe de ~2.7 TB est monté sur `/scratch`. Basculer le cache HF :
+
+```bash
+# Nettoyer les downloads partiels sur /
+rm -rf /workspace/hf_cache/models--*<partiel>*
+
+# Déplacer ce qui a déjà été téléchargé
+mkdir -p /scratch/hf_cache
+mv /workspace/hf_cache/* /workspace/hf_cache/.[!.]* /scratch/hf_cache/ 2>/dev/null || true
+
+# Remplacer le dossier par un symlink
+rm -rf /workspace/hf_cache
+ln -s /scratch/hf_cache /workspace/hf_cache
+
+# Vérifier puis relancer
+df -h / /scratch
+bash download_models.sh
+```
+
+Vérifier à l'avance avec `lsblk` : si un `/dev/sdb` ou `/dev/nvme1n1` de plusieurs TB est listé et monté sur `/scratch`, utiliser ce chemin. Si rien n'est monté, le formater et le monter manuellement (`mkfs.ext4` + `mount`).
+
+**`CUDA out of memory` au chargement** — baisser `--gpu-memory-utilization` (dans `serve_vllm.sh`) à `0.85` ou `--max-model-len` à `16384`.
+
+**`Model not found` côté client** — vérifier le nom exact avec `curl $VLLM_BASE_URL/models`. vLLM expose la dernière portion du repo id sauf si `--served-model-name` est override.
+
+**Téléchargement lent** — vérifier que `hf_transfer` est bien installé (`HF_HUB_ENABLE_HF_TRANSFER=1` dans `download_models.sh`). Sur Scaleway la bande passante est généralement > 500 MB/s.
+
+**MoE qui refuse de charger** — ajouter `--enforce-eager` dans `serve_vllm.sh` pour désactiver CUDA graphs si le compile échoue.
+
+**Qwen2.5-VL ne reçoit pas l'image** — le provider envoie déjà `image_url` en base64, géré nativement par vLLM. Si l'image n'est pas prise en compte, vérifier que `--limit-mm-per-prompt image=4` est bien passé (c'est fait automatiquement par `serve_vllm.sh` pour tout repo contenant `VL`).
+
+## Coûts
+
+vLLM étant self-hosted, le coût ne dépend pas des tokens mais du temps d'occupation de l'instance H100. Le `CostTracker` calcule :
+
+```
+cost_usd = elapsed_hours × VLLM_HOURLY_EUR × EUR_TO_USD
+```
+
+avec `VLLM_HOURLY_EUR=2.8` et `EUR_TO_USD=1.08` par défaut dans [cost_tracker.py](../utils/cost_tracker.py). Les tokens restent comptés et exposés dans le `summary.json`, mais ne sont pas facturés.
+
+Si tu changes de plan Scaleway, ajuste `VLLM_HOURLY_EUR`. Pour ajouter un nouveau modèle self-hosté, ajoute son nom exposé (celui passé à `--served-model-name`) dans le set `VLLM_MODELS`.

--- a/trocr_handwritten/utils/cost_tracker.py
+++ b/trocr_handwritten/utils/cost_tracker.py
@@ -28,6 +28,20 @@ PRICING = {
     "ministral-14b-2512": {"input": 0.20, "output": 0.20},
 }
 
+VLLM_HOURLY_EUR = 2.8
+EUR_TO_USD = 1.08
+
+VLLM_MODELS = {
+    "gemma-4-26B-A4B-it",
+    "Qwen3.6-35B-A3B",
+    "Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR",
+}
+
+
+def is_vllm_model(model_name: str) -> bool:
+    """Return True if the model is self-hosted via vLLM (time-based billing)."""
+    return model_name in VLLM_MODELS
+
 
 @dataclass
 class CostTracker:
@@ -61,9 +75,13 @@ class CostTracker:
         """
         Calculate total cost in USD.
 
-        Returns:
-            Total cost based on token usage and model pricing.
+        For vLLM self-hosted models, cost is proportional to elapsed runtime
+        (H100 instance at VLLM_HOURLY_EUR/h). For API models, cost is based on
+        token usage and per-model pricing.
         """
+        if is_vllm_model(self.model_name):
+            hours = self.elapsed_seconds() / 3600.0
+            return hours * VLLM_HOURLY_EUR * EUR_TO_USD
         pricing = self._pricing.get(self.model_name, {"input": 0.0, "output": 0.0})
         input_cost = (self.input_tokens / 1_000_000) * pricing["input"]
         output_cost = (self.output_tokens / 1_000_000) * pricing["output"]
@@ -92,7 +110,13 @@ class CostTracker:
         ]
         if self.thinking_tokens:
             lines.append(f"Thinking tokens: {self.thinking_tokens:,}")
-        lines.append(f"Estimated cost: ${cost:.4f}")
+        if is_vllm_model(self.model_name):
+            lines.append(
+                f"Estimated cost: ${cost:.4f} "
+                f"(vLLM: {VLLM_HOURLY_EUR}€/h × {elapsed/3600:.3f}h)"
+            )
+        else:
+            lines.append(f"Estimated cost: ${cost:.4f}")
         lines.append(f"Elapsed time: {minutes}m{seconds:02d}s")
         return "\n".join(lines)
 


### PR DESCRIPTION
## Impact & Purpose
Enables running OCR inference on self-hosted models (Gemma 4 26B, Qwen 3.6 35B, Qwen 2.5-VL 7B) via a Scaleway H100 at 10-90× lower cost than managed APIs, with no data leaving the infrastructure.

## Overview
Adds a `vllm` provider that exposes any vLLM-served model through the existing OpenAI-compatible client, wires it into the CLI, and ships H100 deployment scripts + a step-by-step tutorial.

## Key Changes
- New `VLLMProvider` reusing the OpenAI SDK with configurable `base_url` and `timeout`
- `disable_thinking` flag strips `<think>…</think>` blocks for Qwen3-family models
- Time-based cost tracking for self-hosted models (2.8 €/h × elapsed → USD) instead of per-token pricing
- Default `max_tokens` lowered to 16 000 to stay within vLLM `max_model_len=32768`
- Shell scripts: `setup_h100.sh`, `download_models.sh`, `serve_vllm.sh`
- Full deployment tutorial in `trocr_handwritten/llm/vllm.md` (SSH, disk layout, tmux, tunnel, troubleshooting)

## Files Changed
- `trocr_handwritten/llm/providers/vllm.py`: new provider (`_build_kwargs`, `_strip_thinking`, sync + async calls)
- `trocr_handwritten/llm/factory.py`: register `vllm` in `PROVIDERS`
- `trocr_handwritten/llm/settings.py`: `vllm_base_url`, `vllm_api_key`, `request_timeout`, `disable_thinking`, `max_tokens` default
- `trocr_handwritten/llm/ocr.py`: CLI flags `--vllm_base_url`, `--vllm_api_key`, `--max_tokens`, `--request_timeout`, `--disable_thinking`
- `trocr_handwritten/utils/cost_tracker.py`: `VLLM_MODELS` set, `is_vllm_model()`, time-based `get_cost()`
- `trocr_handwritten/llm/deployment/setup_h100.sh`: installs uv, vLLM, cuda-toolkit-12-8, sets CUDA_HOME
- `trocr_handwritten/llm/deployment/download_models.sh`: downloads 3 target models to `/scratch/hf_cache`
- `trocr_handwritten/llm/deployment/serve_vllm.sh`: launches vLLM with multimodal support by default
- `trocr_handwritten/llm/vllm.md`: end-to-end H100 deployment and client usage tutorial

## Testing
```bash
# Start vLLM on H100 (see vllm.md)
bash trocr_handwritten/llm/deployment/serve_vllm.sh Qwen/Qwen3.6-35B-A3B

# Open SSH tunnel from local machine
ssh -N -L 8000:localhost:8000 root@<IP>

# Run OCR on test set
uv run python -m trocr_handwritten.llm.ocr \
    --provider vllm --model Qwen3.6-35B-A3B \
    --input_dir data/ocr/test/images --pattern "*/*.jpg" \
    --output_dir data/ocr/test/predictions/qwen3.6-35b \
    --disable_thinking --max_concurrent 8
```

## Review Notes
- `VLLM_BASE_URL` and `VLLM_API_KEY` are read from `.env` — add to `.env.example` if one exists
- `serve_vllm.sh` enables multimodal by default (`--limit-mm-per-prompt '{"image": 4}'`); set `SERVE_TEXT_ONLY=1` to disable for pure-text models
- Scaleway H100 instances ship without `nvcc` — `setup_h100.sh` now installs `cuda-toolkit-12-8` (required by FlashInfer JIT for Qwen3-Next architecture)
- Cost tracking for vLLM uses a hardcoded `VLLM_HOURLY_EUR=2.8` in `cost_tracker.py` — update if the instance plan changes