### PR TITLE
feat(finetune): add LoRA fine-tuning module with settings, manifests, and pre-training

### DIFF
--- a/tests/test_annotation.py
+++ b/tests/test_annotation.py
@@ -1,0 +1,105 @@
+import json
+
+from trocr_handwritten.utils.annotation import (
+    SPLITS,
+    assign_split,
+    page_key,
+    regroup_by_page,
+)
+
+
+class TestPageKey:
+    """Tests for the page_key helper."""
+
+    def test_strips_crop_index(self):
+        assert (
+            page_key("FRANOM22_COLH78_0261_0238_5.jpg") == "FRANOM22_COLH78_0261_0238"
+        )
+
+    def test_handles_dafcaom_naming(self):
+        assert (
+            page_key("0001_DAFCAOM04_DPPCEC_850116_0029_005")
+            == "0001_DAFCAOM04_DPPCEC_850116_0029"
+        )
+
+    def test_crops_of_same_page_share_key(self):
+        a = page_key("FRANOM58_078MIOM0839_0266_3.jpg")
+        b = page_key("FRANOM58_078MIOM0839_0266_11.jpg")
+        assert a == b
+
+    def test_no_trailing_index_returns_stem(self):
+        assert page_key("000.jpg") == "000"
+
+
+class TestAssignSplit:
+    """Tests for the page-aware assign_split."""
+
+    def test_reuses_split_of_same_page(self):
+        annotations = [{"filename": "FRANOM22_COLH78_0261_0238_0.jpg", "split": "test"}]
+        result = assign_split("FRANOM22_COLH78_0261_0238_9.jpg", annotations)
+        assert result == "test"
+
+    def test_falls_back_to_random_without_context(self):
+        assert assign_split() in SPLITS
+
+
+def _make_crop(base, split, subfolder, stem, text):
+    img = base / split / "images" / subfolder / f"{stem}.jpg"
+    lbl = base / split / "labels" / subfolder / f"{stem}.txt"
+    img.parent.mkdir(parents=True, exist_ok=True)
+    lbl.parent.mkdir(parents=True, exist_ok=True)
+    img.write_bytes(b"fake")
+    lbl.write_text(text, encoding="utf-8")
+
+
+class TestRegroupByPage:
+    """Tests for regroup_by_page."""
+
+    def test_removes_page_leakage(self, tmp_path):
+        _make_crop(tmp_path, "train", "Plein Texte", "DOC_0001_0", "a")
+        _make_crop(tmp_path, "test", "Marge", "DOC_0001_1", "b")
+        _make_crop(tmp_path, "dev", "Nom", "DOC_0001_2", "c")
+
+        regroup_by_page(tmp_path)
+
+        splits = set()
+        for split in SPLITS:
+            for img in (tmp_path / split / "images").rglob("*.jpg"):
+                if page_key(img.name) == "DOC_0001":
+                    splits.add(split)
+        assert len(splits) == 1
+
+    def test_annotations_consistent_with_disk(self, tmp_path):
+        for i in range(20):
+            _make_crop(tmp_path, "train", "Plein Texte", f"DOC_{i:04d}_0", "x")
+
+        regroup_by_page(tmp_path)
+
+        for split in SPLITS:
+            ann_path = tmp_path / split / "annotations.json"
+            if not ann_path.exists():
+                continue
+            ann = json.loads(ann_path.read_text(encoding="utf-8"))
+            disk = list((tmp_path / split / "images").rglob("*.jpg"))
+            assert len(ann) == len(disk)
+
+    def test_drops_duplicate_copies(self, tmp_path):
+        _make_crop(tmp_path, "train", "Nom", "DOC_0001_0", "same")
+        _make_crop(tmp_path, "dev", "Nom", "DOC_0001_0", "same")
+
+        regroup_by_page(tmp_path)
+
+        copies = [
+            img
+            for split in SPLITS
+            for img in (tmp_path / split / "images").rglob("DOC_0001_0.jpg")
+        ]
+        assert len(copies) == 1
+
+    def test_idempotent(self, tmp_path):
+        for i in range(15):
+            _make_crop(tmp_path, "train", "Plein Texte", f"DOC_{i:04d}_0", "x")
+
+        first = regroup_by_page(tmp_path)
+        second = regroup_by_page(tmp_path)
+        assert first == second

--- a/trocr_handwritten/llm/annotate.py
+++ b/trocr_handwritten/llm/annotate.py
@@ -293,7 +293,7 @@ class OCRAnnotationHandler(SimpleHTTPRequestHandler):
         if existing:
             existing["text"] = text
         else:
-            split = assign_split()
+            split = assign_split(filename, annotations)
             annotations.append(
                 {
                     "filename": filename,

--- a/trocr_handwritten/llm/deployment/download_models.sh
+++ b/trocr_handwritten/llm/deployment/download_models.sh
@@ -1,19 +1,45 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Pre-download the three target models into the HF cache so that the first
-# vLLM startup is instant. Requires HF_TOKEN to be exported in the shell
-# for gated repos (Gemma).
+# Pre-download target models into the HF cache so the first vLLM startup is
+# instant. Requires HF_TOKEN to be exported for gated repos (Gemma).
+#
+# Usage:
+#   bash download_models.sh                 # download the whole catalogue
+#   bash download_models.sh Qwen/Qwen3-VL-8B-Instruct google/gemma-4-12B-it
+#
+# Note: the full catalogue is several hundred GB. vLLM also auto-downloads a
+# model on first `serve_vllm.sh`, so pre-warming is optional.
 
 : "${HF_HOME:=/workspace/hf_cache}"
 export HF_HOME
 export HF_HUB_ENABLE_HF_TRANSFER=1
 
-MODELS=(
+if [ -f /workspace/.venv/bin/activate ]; then
+    # shellcheck disable=SC1091
+    source /workspace/.venv/bin/activate
+fi
+
+# Catalogue of OCR-candidate vision models (each fits on a single 80GB H100).
+CATALOGUE=(
+    # --- already benchmarked ---
     "google/gemma-4-26B-A4B-it"
     "Qwen/Qwen3.6-35B-A3B"
     "Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR"
+    # --- new fine-tuning candidates ---
+    "deepseek-ai/DeepSeek-OCR-2"
+    "Qwen/Qwen3-VL-2B-Instruct"
+    "Qwen/Qwen3-VL-8B-Instruct"
+    "Qwen/Qwen3-VL-32B-Instruct"
+    "google/gemma-4-12B-it"
+    "google/gemma-4-31B-it"
 )
+
+if [ $# -gt 0 ]; then
+    MODELS=("$@")
+else
+    MODELS=("${CATALOGUE[@]}")
+fi
 
 if [ -z "${HF_TOKEN:-}" ]; then
     echo "Warning: HF_TOKEN is not set. Gated models (e.g. Gemma) will fail to download."
@@ -23,10 +49,10 @@ for model in "${MODELS[@]}"; do
     echo ""
     echo "==> Downloading $model"
     hf download "$model" \
-        --token "${HF_TOKEN:-}" \
+        ${HF_TOKEN:+--token "$HF_TOKEN"} \
         --cache-dir "$HF_HOME"
 done
 
 echo ""
-echo "All models downloaded to $HF_HOME"
+echo "Downloaded to $HF_HOME"
 du -sh "$HF_HOME"

--- a/trocr_handwritten/llm/deployment/serve_vllm.sh
+++ b/trocr_handwritten/llm/deployment/serve_vllm.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Launch a vLLM OpenAI-compatible server for a single model.
+# Launch a vLLM OpenAI-compatible server for a single model on one 80GB H100.
 # Usage:
 #   bash serve_vllm.sh <hf_repo_id> [port]
 #
 # Examples:
-#   bash serve_vllm.sh google/gemma-4-26B-A4B-it
-#   bash serve_vllm.sh Qwen/Qwen3.6-35B-A3B 8000
-#   bash serve_vllm.sh Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR
+#   bash serve_vllm.sh Qwen/Qwen3-VL-8B-Instruct
+#   bash serve_vllm.sh google/gemma-4-12B-it 8000
+#   bash serve_vllm.sh deepseek-ai/DeepSeek-OCR-2
+#
+# Per-model defaults (ctx, gpu-util) are auto-selected so large dense models
+# (32B/31B) fit on a single card. Override with MAX_MODEL_LEN / GPU_MEM_UTIL /
+# DTYPE env vars. Set SERVE_TEXT_ONLY=1 for pure-text models (no image slots).
 
 if [ $# -lt 1 ]; then
     echo "Usage: $0 <hf_repo_id> [port]"
@@ -22,23 +26,62 @@ PORT="${2:-8000}"
 export HF_HOME
 export VLLM_WORKER_MULTIPROC_METHOD=spawn
 
+# Qwen3-Next (e.g. Qwen3.6-35B-A3B) builds FlashInfer JIT kernels at startup and
+# needs nvcc on PATH; a bare tmux/ssh shell does not have it.
+if [ -d /usr/local/cuda-12.8 ]; then
+    export CUDA_HOME=/usr/local/cuda-12.8
+    export PATH="$CUDA_HOME/bin:$PATH"
+fi
+
 if [ -f /workspace/.venv/bin/activate ]; then
     # shellcheck disable=SC1091
     source /workspace/.venv/bin/activate
 fi
 
-# Vision-Language models need image input slots. Non-VL models do not.
-# Defaults to enabling multimodal; export SERVE_TEXT_ONLY=1 to disable for
-# pure-text models.
+# Defaults tuned for a single 80GB H100. Large dense models get a shorter
+# context and higher memory utilization so weights + KV cache fit.
+DEF_MAX_LEN=32768
+DEF_GPU_UTIL=0.90
+case "$MODEL" in
+    *32B*|*31B*|*35B*)
+        DEF_MAX_LEN=16384
+        DEF_GPU_UTIL=0.95
+        ;;
+    *DeepSeek-OCR*)
+        # DeepSeek-OCR caps at 8192 positions; a higher ctx fails validation.
+        DEF_MAX_LEN=8192
+        ;;
+esac
+
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-$DEF_MAX_LEN}"
+GPU_MEM_UTIL="${GPU_MEM_UTIL:-$DEF_GPU_UTIL}"
+DTYPE="${DTYPE:-bfloat16}"
+
+# Vision-Language models need image input slots; pure-text models do not.
 EXTRA_ARGS=()
 if [ -z "${SERVE_TEXT_ONLY:-}" ]; then
     EXTRA_ARGS+=(--limit-mm-per-prompt '{"image": 4}')
 fi
 
-# MoE models benefit from enforce-eager off and longer ctx; defaults kept simple.
+# Higher input resolution for tall/dense crops. MAX_PIXELS (Qwen-VL) raises the
+# pixel budget before downscaling; PAN_AND_SCAN=1 (Gemma) tiles instead of
+# shrinking. They are mutually exclusive per model.
+if [ -n "${MAX_PIXELS:-}" ]; then
+    EXTRA_ARGS+=(--mm-processor-kwargs "{\"max_pixels\": ${MAX_PIXELS}}")
+elif [ "${PAN_AND_SCAN:-0}" = "1" ]; then
+    EXTRA_ARGS+=(--mm-processor-kwargs '{"do_pan_and_scan": true}')
+fi
+
+# Serve a LoRA adapter alongside the base model, exposed as model name "ft".
+if [ -n "${LORA_PATH:-}" ]; then
+    EXTRA_ARGS+=(--enable-lora --max-lora-rank "${LORA_RANK:-16}"
+        --lora-modules "ft=${LORA_PATH}")
+fi
+
 SERVED_NAME="$(basename "$MODEL")"
 
 echo "==> Serving $MODEL as '$SERVED_NAME' on :$PORT"
+echo "==> ctx=$MAX_MODEL_LEN gpu-util=$GPU_MEM_UTIL dtype=$DTYPE"
 echo "==> OpenAI endpoint will be: http://<host>:$PORT/v1"
 
 vllm serve "$MODEL" \
@@ -46,8 +89,8 @@ vllm serve "$MODEL" \
     --port "$PORT" \
     --served-model-name "$SERVED_NAME" \
     --download-dir "$HF_HOME" \
-    --dtype bfloat16 \
-    --max-model-len 32768 \
-    --gpu-memory-utilization 0.90 \
+    --dtype "$DTYPE" \
+    --max-model-len "$MAX_MODEL_LEN" \
+    --gpu-memory-utilization "$GPU_MEM_UTIL" \
     --trust-remote-code \
     "${EXTRA_ARGS[@]}"

--- a/trocr_handwritten/llm/deployment/setup_h100.sh
+++ b/trocr_handwritten/llm/deployment/setup_h100.sh
@@ -38,7 +38,8 @@ fi
 source .venv/bin/activate
 
 uv pip install --upgrade pip
-uv pip install "vllm>=0.7.0" "huggingface_hub[cli]" "hf_transfer"
+# Qwen3-VL and DeepSeek-OCR-2 need a recent vLLM with their model definitions.
+uv pip install "vllm>=0.11.0" "huggingface_hub[cli]" "hf_transfer"
 
 echo "==> HuggingFace cache dir: $HF_HOME"
 mkdir -p "$HF_HOME"

--- a/trocr_handwritten/llm/finetune/curve.py
+++ b/trocr_handwritten/llm/finetune/curve.py
@@ -1,0 +1,57 @@
+import argparse
+import json
+from pathlib import Path
+
+from trocr_handwritten.llm.finetune.settings import CurveSettings
+
+
+def stats(metrics_path):
+    """Return (cer_mean, cer_median, cer_std, n) from a metrics.json, or None."""
+    p = Path(metrics_path)
+    if not p.exists():
+        return None
+    g = json.loads(p.read_text())["global"]
+    return g["cer_mean"], g["cer_median"], g["cer_std"], g["n"]
+
+
+def cell(key, palier, split, settings):
+    """Resolve the metrics.json path for one (key, palier, split) cell."""
+    root = settings.ocr_dir
+    if palier == 0:
+        if split == "test":
+            return stats(
+                f"{root}/test/predictions/{settings.basepred[key]}/metrics.json"
+            )
+        return stats(f"{root}/dev/predictions/zs-{key}/metrics.json")
+    return stats(f"{root}/{split}/predictions/ft-{key}-{palier}/metrics.json")
+
+
+def main():
+    settings = CurveSettings()
+    parser = argparse.ArgumentParser(description="Print LoRA learning curves.")
+    parser.add_argument("--ocr-dir", default=settings.ocr_dir)
+    args = parser.parse_args()
+    settings = settings.model_copy(update={"ocr_dir": args.ocr_dir})
+
+    for key in settings.keys:
+        print(f"\n=== {key} (CER clipped@1) ===")
+        print(
+            f"{'palier':>6} | {'dev mean':>8} {'median':>7} {'std':>6} "
+            f"| {'test mean':>9} {'median':>7} {'std':>6}"
+        )
+        for p in settings.paliers:
+            d = cell(key, p, "dev", settings)
+            t = cell(key, p, "test", settings)
+
+            def fmt(s):
+                return (
+                    f"{s[0]:>8.4f} {s[1]:>7.4f} {s[2]:>6.3f}"
+                    if s
+                    else f"{'-':>8} {'-':>7} {'-':>6}"
+                )
+
+            print(f"{p:>6} | {fmt(d)} | {fmt(t)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/trocr_handwritten/llm/finetune/manifest.py
+++ b/trocr_handwritten/llm/finetune/manifest.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+
+
+def write_manifest(path, records):
+    """Write records as one JSON object per line (jsonl manifest)."""
+    Path(path).write_text(
+        "\n".join(json.dumps(r, ensure_ascii=False) for r in records),
+        encoding="utf-8",
+    )
+
+
+def proportional_take(strata, size):
+    """
+    Select `size` records across pre-ordered strata, preserving proportions.
+
+    Each stratum contributes round(size * len / total) of its leading items, then
+    the selection is topped up to the exact size from remaining items in stratum
+    order. Callers shuffle the strata beforehand; reusing the same shuffled strata
+    across increasing sizes yields nested subsets.
+
+    Args:
+        strata: Mapping of stratum key -> ordered list of records.
+        size: Target number of records.
+
+    Returns:
+        list: The selected records.
+    """
+    total = sum(len(v) for v in strata.values())
+    if total == 0:
+        return []
+    size = min(size, total)
+    chosen, seen = [], set()
+    for items in strata.values():
+        k = round(size * len(items) / total)
+        for r in items[:k]:
+            chosen.append(r)
+            seen.add(id(r))
+    if len(chosen) >= size:
+        return chosen[:size]
+    for items in strata.values():
+        for r in items:
+            if id(r) not in seen:
+                chosen.append(r)
+                seen.add(id(r))
+                if len(chosen) == size:
+                    return chosen
+    return chosen

--- a/trocr_handwritten/llm/finetune/prepare_data.py
+++ b/trocr_handwritten/llm/finetune/prepare_data.py
@@ -1,0 +1,94 @@
+import argparse
+import random
+from collections import Counter, defaultdict
+from pathlib import Path
+
+from trocr_handwritten.llm.finetune.manifest import proportional_take, write_manifest
+from trocr_handwritten.llm.finetune.settings import DataSettings
+
+
+def collect_split(base: Path, split: str):
+    """
+    Collect (relative_image_path, region, text) for every labelled crop in a split.
+
+    Args:
+        base: Root OCR directory (e.g. data/ocr).
+        split: One of train/dev/test.
+
+    Returns:
+        list: Records with rel_image, region, text.
+    """
+    records = []
+    labels_root = base / split / "labels"
+    for lbl in sorted(labels_root.rglob("*.txt")):
+        region = lbl.parent.name
+        text = lbl.read_text(encoding="utf-8").strip()
+        if not text:
+            continue
+        img = None
+        for ext in (".jpg", ".jpeg", ".png"):
+            cand = base / split / "images" / region / f"{lbl.stem}{ext}"
+            if cand.exists():
+                img = f"{split}/images/{region}/{lbl.stem}{ext}"
+                break
+        if img is None:
+            continue
+        records.append({"image": img, "region": region, "text": text})
+    return records
+
+
+def nested_stratified_subsets(records, paliers, seed=42):
+    """
+    Build nested, region-stratified subsets of increasing size.
+
+    Args:
+        records: Full train records.
+        paliers: Sorted target sizes.
+        seed: Shuffle seed.
+
+    Returns:
+        dict: size -> list of records.
+    """
+    rng = random.Random(seed)
+    by_region = defaultdict(list)
+    for r in records:
+        by_region[r["region"]].append(r)
+    for reg in by_region:
+        rng.shuffle(by_region[reg])
+    return {size: proportional_take(by_region, size) for size in paliers}
+
+
+def main():
+    settings = DataSettings()
+    parser = argparse.ArgumentParser(description="Prepare VLM fine-tuning manifests.")
+    parser.add_argument("--ocr-dir", default=settings.ocr_dir)
+    parser.add_argument("--out-dir", default=settings.out_dir)
+    parser.add_argument("--seed", type=int, default=settings.seed)
+    args = parser.parse_args()
+
+    base = Path(args.ocr_dir)
+    out = Path(args.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    for split in settings.eval_splits:
+        recs = collect_split(base, split)
+        write_manifest(out / f"{split}.jsonl", recs)
+        print(f"{split}: {len(recs)} records")
+
+    train = collect_split(base, settings.train_split)
+    print(f"train full: {len(train)} records")
+    subsets = nested_stratified_subsets(train, settings.paliers, seed=args.seed)
+
+    prev = set()
+    for size in settings.paliers:
+        recs = subsets[size]
+        write_manifest(out / f"train_{size}.jsonl", recs)
+        keys = {r["image"] for r in recs}
+        nested = prev.issubset(keys)
+        reg = Counter(r["region"] for r in recs)
+        print(f"train_{size}: {len(recs)} | nested={nested} | {dict(reg)}")
+        prev = keys
+
+
+if __name__ == "__main__":
+    main()

--- a/trocr_handwritten/llm/finetune/prepare_teklia.py
+++ b/trocr_handwritten/llm/finetune/prepare_teklia.py
@@ -1,0 +1,159 @@
+import argparse
+import random
+from collections import Counter, defaultdict
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+
+import requests
+from datasets import load_dataset
+
+from trocr_handwritten.llm.finetune.manifest import proportional_take, write_manifest
+from trocr_handwritten.llm.finetune.settings import TekliaSettings
+
+
+def century(value):
+    """Map a start_date (int year, possibly 0/unknown) to a century bucket key."""
+    try:
+        year = int(value)
+    except (TypeError, ValueError):
+        return "unk"
+    if year <= 0:
+        return "unk"
+    return str(year // 100 + 1)
+
+
+def collect_rows(settings):
+    """
+    Load RecordGold rows that carry a public IIIF image URL and non-empty text.
+
+    Args:
+        settings: TekliaSettings.
+
+    Returns:
+        list: Records with record_id, url, text, parish, bucket.
+    """
+    ds = load_dataset(settings.dataset, split=settings.split)
+    rows = []
+    for r in ds:
+        url = r.get("record_url") or ""
+        text = (r.get("text") or "").strip()
+        if settings.iiif_host not in url or not text:
+            continue
+        rows.append(
+            {
+                "record_id": str(r.get("record_id")),
+                "url": url,
+                "text": text,
+                "parish": r.get("parish") or "unk",
+                "bucket": century(r.get("start_date")),
+            }
+        )
+    return rows
+
+
+def stratified_sample(rows, max_samples, seed=42):
+    """
+    Take a stratified subsample by parish x century, preserving proportions.
+
+    Args:
+        rows: Full row list.
+        max_samples: Target size, or None to keep all.
+        seed: Shuffle seed.
+
+    Returns:
+        list: Subsampled rows.
+    """
+    if not max_samples or max_samples >= len(rows):
+        return rows
+    rng = random.Random(seed)
+    by_key = defaultdict(list)
+    for r in rows:
+        by_key[(r["parish"], r["bucket"])].append(r)
+    for key in by_key:
+        rng.shuffle(by_key[key])
+    return proportional_take(by_key, max_samples)
+
+
+def fetch_image(row, img_dir, session, settings):
+    """Download one IIIF region image to disk, returning the path or None."""
+    dest = img_dir / f"{row['record_id']}.jpg"
+    if dest.exists() and dest.stat().st_size > 0:
+        return dest
+    for _ in range(settings.retries):
+        try:
+            resp = session.get(row["url"], timeout=settings.timeout)
+            if resp.status_code == 200 and resp.content:
+                dest.write_bytes(resp.content)
+                return dest
+        except requests.RequestException:
+            pass
+    return None
+
+
+def download_all(rows, img_dir, settings):
+    """Download every row's image concurrently, returning rows that succeeded."""
+    img_dir.mkdir(parents=True, exist_ok=True)
+    ok = []
+    session = requests.Session()
+    session.headers.update({"User-Agent": settings.user_agent})
+    with ThreadPoolExecutor(max_workers=settings.workers) as pool:
+        futures = {
+            pool.submit(fetch_image, r, img_dir, session, settings): r for r in rows
+        }
+        done = 0
+        for fut in as_completed(futures):
+            if fut.result() is not None:
+                ok.append(futures[fut])
+            done += 1
+            if done % 500 == 0:
+                print(f"  downloaded {done}/{len(rows)} ({len(ok)} ok)")
+    return ok
+
+
+def main():
+    settings = TekliaSettings()
+    parser = argparse.ArgumentParser(
+        description="Download RecordGold IIIF images and write a fine-tuning manifest."
+    )
+    parser.add_argument("--out-dir", default=settings.out_dir)
+    parser.add_argument("--split", default=settings.split)
+    parser.add_argument("--max-samples", type=int, default=settings.max_samples)
+    parser.add_argument("--workers", type=int, default=settings.workers)
+    parser.add_argument("--seed", type=int, default=settings.seed)
+    args = parser.parse_args()
+
+    settings = settings.model_copy(
+        update={
+            "out_dir": args.out_dir,
+            "split": args.split,
+            "max_samples": args.max_samples,
+            "workers": args.workers,
+            "seed": args.seed,
+        }
+    )
+    out = Path(settings.out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    rows = collect_rows(settings)
+    print(f"{settings.split}: {len(rows)} rows with IIIF image + text")
+    rows = stratified_sample(rows, settings.max_samples, seed=settings.seed)
+    print(f"selected: {len(rows)} | buckets={dict(Counter(r['bucket'] for r in rows))}")
+
+    rows = download_all(rows, out / "images", settings)
+    print(f"downloaded ok: {len(rows)}")
+
+    records = [
+        {
+            "image": f"{settings.region_label}/images/{r['record_id']}.jpg",
+            "region": settings.region_label,
+            "text": r["text"],
+        }
+        for r in rows
+    ]
+    manifest = out / f"{settings.split}.jsonl"
+    write_manifest(manifest, records)
+    print(f"wrote {manifest} ({len(records)} records)")
+
+
+if __name__ == "__main__":
+    main()

--- a/trocr_handwritten/llm/finetune/settings.py
+++ b/trocr_handwritten/llm/finetune/settings.py
@@ -1,0 +1,115 @@
+from typing import Dict, List, Optional
+
+from pydantic import BaseModel, Field
+
+
+class LoraSettings(BaseModel):
+    """Hyper-parameters and paths for LoRA fine-tuning a VLM for OCR."""
+
+    data_root: str = Field(
+        default="data/ocr",
+        description="Root resolved against each manifest's relative image path.",
+    )
+    prompt_path: str = Field(
+        default="config/ocr.prompt",
+        description="Path to the OCR prompt template.",
+    )
+    epochs: float = Field(default=3.0, description="Number of training epochs.")
+    lr: float = Field(default=1e-4, description="Peak learning rate.")
+    lora_rank: int = Field(default=16, description="LoRA rank r.")
+    lora_alpha_ratio: int = Field(
+        default=2, description="lora_alpha = lora_rank * lora_alpha_ratio."
+    )
+    lora_dropout: float = Field(default=0.05, description="LoRA dropout.")
+    target_modules: List[str] = Field(
+        default_factory=lambda: [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+            "gate_proj",
+            "up_proj",
+            "down_proj",
+        ],
+        description="Modules to wrap with LoRA adapters.",
+    )
+    batch_size: int = Field(default=2, description="Per-device train batch size.")
+    grad_accum: int = Field(default=8, description="Gradient accumulation steps.")
+    seed: int = Field(default=42, description="Training and data-order seed.")
+    warmup_ratio: float = Field(default=0.05, description="LR warmup ratio.")
+    lr_scheduler_type: str = Field(default="cosine", description="LR scheduler type.")
+    logging_steps: int = Field(default=5, description="Trainer logging interval.")
+
+
+class DataSettings(BaseModel):
+    """Paths and paliers for building fine-tuning manifests from our OCR splits."""
+
+    ocr_dir: str = Field(default="data/ocr", description="Root OCR directory.")
+    out_dir: str = Field(
+        default="data/ocr/finetune", description="Where manifests are written."
+    )
+    paliers: List[int] = Field(
+        default_factory=lambda: [60, 120, 240, 485, 972],
+        description="Nested subset sizes for the learning curve.",
+    )
+    eval_splits: List[str] = Field(
+        default_factory=lambda: ["dev", "test"],
+        description="Splits written verbatim as manifests.",
+    )
+    train_split: str = Field(
+        default="train", description="Split subsampled into paliers."
+    )
+    seed: int = Field(default=42, description="Subset shuffle seed.")
+
+
+class TekliaSettings(BaseModel):
+    """Source and download parameters for the RecordGold pre-training corpus."""
+
+    dataset: str = Field(
+        default="Teklia/DAI-CReTDHI-RecordGold-ATR",
+        description="HuggingFace dataset id.",
+    )
+    iiif_host: str = Field(
+        default="iiif.teklia.com",
+        description="Substring required in record_url to accept a row.",
+    )
+    region_label: str = Field(
+        default="teklia",
+        description="Region tag written in the manifest and image subpath.",
+    )
+    out_dir: str = Field(
+        default="data/ocr/teklia", description="Output root for images + manifest."
+    )
+    split: str = Field(default="train", description="HF split to pull.")
+    max_samples: Optional[int] = Field(
+        default=None, description="Stratified cap, or None to keep all rows."
+    )
+    workers: int = Field(default=16, description="Concurrent download workers.")
+    retries: int = Field(default=3, description="Per-image download retries.")
+    timeout: int = Field(default=30, description="Per-request timeout (seconds).")
+    user_agent: str = Field(
+        default="dai-cretdhi-research/1.0", description="HTTP User-Agent."
+    )
+    seed: int = Field(default=42, description="Stratified sample seed.")
+
+
+class CurveSettings(BaseModel):
+    """Mapping from model keys to baseline predictions for the curve reporter."""
+
+    ocr_dir: str = Field(default="data/ocr", description="Root OCR directory.")
+    keys: List[str] = Field(
+        default_factory=lambda: ["qwen2b", "qwen8b", "gemma12b"],
+        description="Model keys to report.",
+    )
+    basepred: Dict[str, str] = Field(
+        default_factory=lambda: {
+            "qwen2b": "zs-qwen3-vl-2b",
+            "qwen8b": "zs-qwen3-vl-8b",
+            "gemma12b": "zs-gemma-4-12b",
+        },
+        description="Zero-shot (P0) test prediction dir per model key.",
+    )
+    paliers: List[int] = Field(
+        default_factory=lambda: [0, 60, 120, 240, 485, 972],
+        description="Paliers to report (0 = zero-shot).",
+    )

--- a/trocr_handwritten/llm/finetune/train_lora.py
+++ b/trocr_handwritten/llm/finetune/train_lora.py
@@ -1,0 +1,171 @@
+import argparse
+import json
+import math
+from pathlib import Path
+
+import torch
+from PIL import Image
+from datasets import Dataset
+from peft import LoraConfig, PeftModel, get_peft_model
+from transformers import (
+    AutoModelForImageTextToText,
+    AutoProcessor,
+    Trainer,
+    TrainingArguments,
+)
+
+from trocr_handwritten.llm.finetune.settings import LoraSettings
+from trocr_handwritten.utils.prompt import load_prompt
+
+
+def load_manifest(path, data_root):
+    """Load a jsonl manifest and resolve absolute image paths."""
+    recs = []
+    for line in Path(path).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        r = json.loads(line)
+        r["image_path"] = str(Path(data_root) / r["image"])
+        recs.append(r)
+    return recs
+
+
+def build_messages(prompt, answer=None):
+    """Build a chat conversation with one image and the OCR prompt."""
+    msgs = [
+        {
+            "role": "user",
+            "content": [{"type": "image"}, {"type": "text", "text": prompt}],
+        }
+    ]
+    if answer is not None:
+        msgs.append(
+            {"role": "assistant", "content": [{"type": "text", "text": answer}]}
+        )
+    return msgs
+
+
+class Collator:
+    """Collate VLM SFT batches, masking the prompt prefix and pad tokens."""
+
+    def __init__(self, processor, prompt):
+        self.processor = processor
+        self.prompt = prompt
+        self.tok = processor.tokenizer
+
+    def __call__(self, batch):
+        images = [Image.open(b["image_path"]).convert("RGB") for b in batch]
+        full = [
+            self.processor.apply_chat_template(
+                build_messages(self.prompt, b["text"]), tokenize=False
+            )
+            for b in batch
+        ]
+        enc = self.processor(
+            text=full,
+            images=[[im] for im in images],
+            return_tensors="pt",
+            padding=True,
+        )
+        labels = enc["input_ids"].clone()
+        labels[labels == self.tok.pad_token_id] = -100
+        image_token_id = getattr(self.processor, "image_token_id", None)
+        if image_token_id is not None:
+            labels[enc["input_ids"] == image_token_id] = -100
+        for i, b in enumerate(batch):
+            prefix = self.processor.apply_chat_template(
+                build_messages(self.prompt), tokenize=False, add_generation_prompt=True
+            )
+            plen = self.processor(
+                text=[prefix], images=[[images[i]]], return_tensors="pt"
+            )["input_ids"].shape[1]
+            labels[i, :plen] = -100
+        enc["labels"] = labels
+        return enc
+
+
+def main():
+    s = LoraSettings()
+    parser = argparse.ArgumentParser(description="LoRA fine-tune a VLM for OCR.")
+    parser.add_argument("--model", required=True)
+    parser.add_argument("--train", required=True, help="train manifest jsonl")
+    parser.add_argument("--data-root", default=s.data_root)
+    parser.add_argument("--prompt-path", default=s.prompt_path)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument(
+        "--init-adapter",
+        default=None,
+        help="Path to an existing LoRA adapter to continue training (stage-2).",
+    )
+    parser.add_argument("--epochs", type=float, default=s.epochs)
+    parser.add_argument("--lr", type=float, default=s.lr)
+    parser.add_argument("--lora-rank", type=int, default=s.lora_rank)
+    parser.add_argument("--batch-size", type=int, default=s.batch_size)
+    parser.add_argument("--grad-accum", type=int, default=s.grad_accum)
+    parser.add_argument("--seed", type=int, default=s.seed)
+    args = parser.parse_args()
+
+    prompt = load_prompt(args.prompt_path)
+    model = AutoModelForImageTextToText.from_pretrained(
+        args.model, torch_dtype=torch.bfloat16, device_map="auto"
+    )
+    processor = AutoProcessor.from_pretrained(args.model)
+    if processor.tokenizer.pad_token_id is None:
+        processor.tokenizer.pad_token = processor.tokenizer.eos_token
+
+    train_recs = load_manifest(args.train, args.data_root)
+
+    model.config.use_cache = False
+    if args.init_adapter:
+        model = PeftModel.from_pretrained(model, args.init_adapter, is_trainable=True)
+        print(f"Continuing adapter {args.init_adapter}")
+    else:
+        lora = LoraConfig(
+            r=args.lora_rank,
+            lora_alpha=args.lora_rank * s.lora_alpha_ratio,
+            lora_dropout=s.lora_dropout,
+            bias="none",
+            target_modules=s.target_modules,
+            task_type="CAUSAL_LM",
+        )
+        model = get_peft_model(model, lora)
+    model.enable_input_require_grads()
+    model.print_trainable_parameters()
+
+    dataset = Dataset.from_list(train_recs)
+    steps = (
+        math.ceil(len(train_recs) / (args.batch_size * args.grad_accum)) * args.epochs
+    )
+    targs = TrainingArguments(
+        output_dir=args.output_dir,
+        per_device_train_batch_size=args.batch_size,
+        gradient_accumulation_steps=args.grad_accum,
+        num_train_epochs=args.epochs,
+        learning_rate=args.lr,
+        seed=args.seed,
+        data_seed=args.seed,
+        bf16=True,
+        logging_steps=s.logging_steps,
+        save_strategy="no",
+        warmup_ratio=s.warmup_ratio,
+        lr_scheduler_type=s.lr_scheduler_type,
+        gradient_checkpointing=True,
+        remove_unused_columns=False,
+        report_to="none",
+    )
+    trainer = Trainer(
+        model=model,
+        args=targs,
+        train_dataset=dataset,
+        data_collator=Collator(processor, prompt),
+    )
+    print(f"Training {args.model} on {len(train_recs)} samples (~{int(steps)} steps)")
+    trainer.train()
+
+    model.save_pretrained(args.output_dir)
+    processor.save_pretrained(args.output_dir)
+    print(f"SAVED_ADAPTER {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/trocr_handwritten/llm/metrics.py
+++ b/trocr_handwritten/llm/metrics.py
@@ -108,8 +108,8 @@ def compute_metrics(pairs):
     by_subfolder = defaultdict(list)
 
     for subfolder, stem, prediction, reference in pairs:
-        item_cer = jiwer.cer(reference, prediction)
-        item_wer = jiwer.wer(reference, prediction)
+        item_cer = min(jiwer.cer(reference, prediction), 1.0)
+        item_wer = min(jiwer.wer(reference, prediction), 1.0)
         item_lev = _levenshtein_distance(reference, prediction)
         item_exact = 1.0 if prediction == reference else 0.0
 

--- a/trocr_handwritten/llm/ocr.py
+++ b/trocr_handwritten/llm/ocr.py
@@ -8,6 +8,7 @@ from tqdm.asyncio import tqdm_asyncio
 
 from trocr_handwritten.utils.logging_config import get_logger
 from trocr_handwritten.utils.cost_tracker import CostTracker
+from trocr_handwritten.utils.prompt import load_prompt
 from trocr_handwritten.llm.settings import LLMSettings, OCRSettings
 from trocr_handwritten.llm.factory import get_provider
 
@@ -34,20 +35,6 @@ def find_images(
     if limit:
         images = images[:limit]
     return images
-
-
-def load_prompt(prompt_path: str) -> str:
-    """
-    Load the OCR prompt template from file.
-
-    Args:
-        prompt_path: Path to the prompt file.
-
-    Returns:
-        Prompt template string.
-    """
-    with open(prompt_path, "r", encoding="utf-8") as f:
-        return f.read()
 
 
 async def process_image_async(

--- a/trocr_handwritten/llm/providers/vllm.py
+++ b/trocr_handwritten/llm/providers/vllm.py
@@ -76,22 +76,57 @@ class VLLMProvider(LLMProvider):
             return text.split("</think>", 1)[1].lstrip("\n ")
         return text
 
-    def _call_api(self, model: str, messages: list) -> Tuple[str, int, int]:
-        """Make a synchronous API call."""
-        response = self.client.chat.completions.create(
-            **self._build_kwargs(model, messages)
-        )
-        text = self._strip_thinking(response.choices[0].message.content)
+    @staticmethod
+    def _extract(response) -> Tuple[str, int, int]:
+        """Pull stripped text and token usage out of a completion response."""
+        text = VLLMProvider._strip_thinking(response.choices[0].message.content)
         input_tokens = response.usage.prompt_tokens if response.usage else 0
         output_tokens = response.usage.completion_tokens if response.usage else 0
         return text, input_tokens, output_tokens
 
-    async def _call_api_async(self, model: str, messages: list) -> Tuple[str, int, int]:
-        """Make an asynchronous API call."""
-        response = await self.async_client.chat.completions.create(
-            **self._build_kwargs(model, messages)
+    def _retry_kwargs(self, model: str, messages: list) -> dict:
+        """Kwargs for an empty-response retry, forcing sampling to break greedy EOS."""
+        kwargs = self._build_kwargs(model, messages)
+        kwargs["temperature"] = max(self.settings.temperature, 0.5)
+        return kwargs
+
+    def _call_api(self, model: str, messages: list) -> Tuple[str, int, int]:
+        """Make a synchronous API call, retrying once with sampling if empty."""
+        text, in_tok, out_tok = self._extract(
+            self.client.chat.completions.create(**self._build_kwargs(model, messages))
         )
-        text = self._strip_thinking(response.choices[0].message.content)
-        input_tokens = response.usage.prompt_tokens if response.usage else 0
-        output_tokens = response.usage.completion_tokens if response.usage else 0
-        return text, input_tokens, output_tokens
+        if not text or not text.strip():
+            rtext, rin, rout = self._extract(
+                self.client.chat.completions.create(
+                    **self._retry_kwargs(model, messages)
+                )
+            )
+            in_tok += rin
+            out_tok += rout
+            if rtext and rtext.strip():
+                text = rtext
+        return text, in_tok, out_tok
+
+    async def _call_api_async(self, model: str, messages: list) -> Tuple[str, int, int]:
+        """Make an async API call, retrying once with sampling if empty.
+
+        Greedy decoding (temperature 0) can emit an immediate stop token on hard
+        or very long crops, yielding an empty transcription. A single sampled
+        retry recovers most of these.
+        """
+        text, in_tok, out_tok = self._extract(
+            await self.async_client.chat.completions.create(
+                **self._build_kwargs(model, messages)
+            )
+        )
+        if not text or not text.strip():
+            rtext, rin, rout = self._extract(
+                await self.async_client.chat.completions.create(
+                    **self._retry_kwargs(model, messages)
+                )
+            )
+            in_tok += rin
+            out_tok += rout
+            if rtext and rtext.strip():
+                text = rtext
+        return text, in_tok, out_tok

--- a/trocr_handwritten/llm/vllm.md
+++ b/trocr_handwritten/llm/vllm.md
@@ -4,19 +4,43 @@ Serve a Hugging Face model behind an OpenAI-compatible API on a Scaleway H100, t
 
 ## Target models
 
-| HF repo | Type | Gated |
-|---|---|---|
-| `google/gemma-4-26B-A4B-it` | Text MoE | Yes (HF token) |
-| `Qwen/Qwen3.6-35B-A3B` | VL MoE (Qwen3-Next) | No |
-| `Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR` | Vision-Language | No |
+Each fits on a single 80GB H100. Large dense models (32B/31B) auto-select a
+shorter context in `serve_vllm.sh` so weights + KV cache fit.
+
+| HF repo | Type | ~VRAM (bf16) | Gated |
+|---|---|---|---|
+| `google/gemma-4-26B-A4B-it` | Text MoE | ~52 GB | Yes (HF token) |
+| `Qwen/Qwen3.6-35B-A3B` | VL MoE (Qwen3-Next) | ~70 GB | No |
+| `Teklia/Qwen2.5-VL-7B-DAI-CReTDHI-RecordGold-ATR` | Vision-Language | ~16 GB | No |
+| `deepseek-ai/DeepSeek-OCR-2` | OCR (3B) | ~6 GB | No |
+| `Qwen/Qwen3-VL-2B-Instruct` | Vision-Language | ~5 GB | No |
+| `Qwen/Qwen3-VL-8B-Instruct` | Vision-Language | ~17 GB | No |
+| `Qwen/Qwen3-VL-32B-Instruct` | Vision-Language (dense) | ~64 GB ⚠️ tight | No |
+| `google/gemma-4-12B-it` | Vision-Language | ~24 GB | Yes (HF token) |
+| `google/gemma-4-31B-it` | Vision-Language (dense) | ~62 GB ⚠️ tight | Yes (HF token) |
+
+The first three are already benchmarked; the rest are fine-tuning candidates.
+For the ⚠️ tight models, if you still hit OOM use FP8 weights (e.g.
+`Qwen/Qwen3-VL-32B-Instruct-FP8`) or lower `GPU_MEM_UTIL`.
 
 ## 1. Provision the instance
 
-Create an **H100-1-80G** (Ubuntu 22.04+) on Scaleway. Verify your SSH key is attached to the account, then:
+Create an **H100-1-80G** (Ubuntu 22.04+) on Scaleway. The default user is
+`ubuntu`. With this `~/.ssh/config` alias:
+
+```
+Host trocr_handwritten
+  Hostname <PUBLIC_IP>
+  User ubuntu
+  IdentityFile ~/.ssh/id_ed25519
+  IdentitiesOnly yes
+```
+
+connect and prepare the workspace:
 
 ```bash
-ssh root@<PUBLIC_IP>
-mkdir -p /workspace && cd /workspace
+ssh trocr_handwritten
+sudo mkdir -p /workspace && sudo chown ubuntu:ubuntu /workspace && cd /workspace
 ```
 
 ## 2. Copy scripts and install
@@ -24,7 +48,7 @@ mkdir -p /workspace && cd /workspace
 From your laptop:
 
 ```bash
-scp trocr_handwritten/llm/deployment/*.sh root@<PUBLIC_IP>:/workspace/
+scp trocr_handwritten/llm/deployment/*.sh trocr_handwritten:/workspace/
 ```
 
 On the H100:
@@ -37,7 +61,7 @@ Installs `uv`, a Python 3.12 venv in `/workspace/.venv`, `vllm`, `huggingface_hu
 
 ## 3. Use `/scratch` for model weights
 
-The root disk (~110 GB) is too small for the three models (~130 GB total). Scaleway H100 instances ship with a 2.7 TB NVMe mounted at `/scratch`:
+The root disk (~110 GB) is too small for the full catalogue (several hundred GB). Scaleway H100 instances ship with a 2.7 TB NVMe mounted at `/scratch`:
 
 ```bash
 mkdir -p /scratch/hf_cache
@@ -47,11 +71,13 @@ ln -s /scratch/hf_cache /workspace/hf_cache
 
 ## 4. Download models
 
-Gemma requires an HF token (gated):
+Gemma requires an HF token (gated). Download the whole catalogue, or just the
+models you want to benchmark (vLLM also auto-downloads on first serve):
 
 ```bash
 export HF_TOKEN=hf_xxxxxxxxxxxxxxxx
-bash download_models.sh
+bash download_models.sh                                    # everything
+bash download_models.sh Qwen/Qwen3-VL-8B-Instruct deepseek-ai/DeepSeek-OCR-2
 ```
 
 ## 5. Serve one model
@@ -60,11 +86,17 @@ Use `tmux` so the server survives SSH disconnects:
 
 ```bash
 tmux new -s vllm
-bash serve_vllm.sh Qwen/Qwen3.6-35B-A3B   # or any of the 3 repos
+bash serve_vllm.sh Qwen/Qwen3-VL-8B-Instruct   # or any repo from the table
 # Ctrl+b then d to detach
 ```
 
-The server listens on `http://0.0.0.0:8000/v1` and exposes the model under the last segment of the repo id (e.g. `Qwen3.6-35B-A3B`). Confirm with:
+`serve_vllm.sh` picks per-model defaults (32B/31B get `ctx=16384`, `gpu-util=0.95`). Override with `MAX_MODEL_LEN`, `GPU_MEM_UTIL`, `DTYPE` env vars, e.g.:
+
+```bash
+GPU_MEM_UTIL=0.92 bash serve_vllm.sh Qwen/Qwen3-VL-32B-Instruct
+```
+
+The server listens on `http://0.0.0.0:8000/v1` and exposes the model under the last segment of the repo id (e.g. `Qwen3-VL-8B-Instruct`). Confirm with:
 
 ```bash
 curl http://localhost:8000/v1/models
@@ -73,7 +105,7 @@ curl http://localhost:8000/v1/models
 ## 6. SSH tunnel from your laptop
 
 ```bash
-ssh -N -L 8000:localhost:8000 root@<PUBLIC_IP>
+ssh -N -L 8000:localhost:8000 trocr_handwritten
 ```
 
 Leave it running.
@@ -89,20 +121,29 @@ VLLM_API_KEY=EMPTY
 
 ## 8. Run OCR
 
+Run locally (the test data lives on your laptop), pointing at the tunnelled endpoint:
+
 ```bash
 uv run python -m trocr_handwritten.llm.ocr \
     --provider vllm \
-    --model Qwen3.6-35B-A3B \
+    --model Qwen3-VL-8B-Instruct \
     --input_dir data/ocr/test/images \
     --pattern "*/*.jpg" \
-    --output_dir data/ocr/test/predictions/qwen3.6-35b \
-    --max_concurrent 8 \
-    --disable_thinking
+    --output_dir data/ocr/test/predictions/qwen3-vl-8b \
+    --max_concurrent 16
+```
+
+Then score against the new (leak-free) test set:
+
+```bash
+uv run python -m trocr_handwritten.llm.metrics \
+    --predictions data/ocr/test/predictions/qwen3-vl-8b \
+    --labels data/ocr/test/labels
 ```
 
 Flags:
-- `--disable_thinking` strips Qwen3 `<think>…</think>` reasoning blocks (big speedup + cleaner output)
-- `--max_concurrent` — 4–8 for 26–35B, 16–32 for 7B
+- `--disable_thinking` strips `<think>…</think>` blocks — use for Qwen3 thinking/MoE models (`Qwen3.6-35B-A3B`); not needed for `*-Instruct` VL models, DeepSeek-OCR, or Gemma
+- `--max_concurrent` — 4–8 for 26–35B, 16–32 for 2–8B
 - `--request_timeout` — defaults to 120s
 
 ## 9. Switch models

--- a/trocr_handwritten/utils/annotation.py
+++ b/trocr_handwritten/utils/annotation.py
@@ -1,6 +1,7 @@
 import colorsys
 import json
 import random
+import re
 import shutil
 from pathlib import Path
 
@@ -8,8 +9,46 @@ SPLIT_WEIGHTS = {"train": 0.7, "test": 0.2, "dev": 0.1}
 SPLITS = list(SPLIT_WEIGHTS.keys())
 
 
-def assign_split():
-    """Randomly assign a split based on SPLIT_WEIGHTS (train=0.7, test=0.2, dev=0.1)."""
+def page_key(filename):
+    """
+    Return the page a crop belongs to by stripping the trailing crop index.
+
+    A crop is named ``<page>_<crop_index>`` across every corpus (FRANOM, FRCAOM,
+    DAFCAOM, p-variant, ...). Removing the final ``_<digits>`` segment yields a
+    stable page identifier so that all crops of the same page share one key.
+
+    Args:
+        filename: Crop file name or stem.
+
+    Returns:
+        str: The page key.
+    """
+    stem = Path(filename).stem
+    m = re.match(r"^(.*)_\d+$", stem)
+    return m.group(1) if m else stem
+
+
+def assign_split(filename=None, annotations=None):
+    """
+    Assign a split, keeping all crops of a page together to avoid leakage.
+
+    When ``filename`` and ``annotations`` are provided and another crop of the
+    same page already has a split, that split is reused so a page never straddles
+    train/test/dev. Otherwise a weighted random draw is used (train=0.7, test=0.2,
+    dev=0.1).
+
+    Args:
+        filename: Crop file name, used to derive the page key.
+        annotations: Existing annotation dicts (each with ``filename`` and ``split``).
+
+    Returns:
+        str: The assigned split.
+    """
+    if filename is not None and annotations:
+        key = page_key(filename)
+        for a in annotations:
+            if a.get("split") and page_key(a["filename"]) == key:
+                return a["split"]
     r = random.random()
     cumulative = 0.0
     for split, weight in SPLIT_WEIGHTS.items():
@@ -82,6 +121,150 @@ def save_split_annotations(annotations, base_dir):
             json.dump(entries, f, indent=2, ensure_ascii=False)
 
 
+def _collect_split_crops(base):
+    """
+    Scan train/dev/test on disk and return one record per crop.
+
+    Disk is the source of truth: annotations.json may be incomplete, so crops are
+    enumerated from the image files and matched with their label text when present.
+
+    Args:
+        base: Root directory containing the split subdirectories.
+
+    Returns:
+        list: Records with filename, subfolder, split, page and text.
+    """
+    extensions = ("*.jpg", "*.jpeg", "*.png")
+    records = []
+    for split in SPLITS:
+        images_root = base / split / "images"
+        if not images_root.exists():
+            continue
+        imgs = []
+        for ext in extensions:
+            imgs.extend(images_root.rglob(ext))
+        for img in sorted(imgs):
+            subfolder = img.parent.name
+            label = base / split / "labels" / subfolder / (img.stem + ".txt")
+            text = label.read_text(encoding="utf-8").strip() if label.exists() else ""
+            records.append(
+                {
+                    "filename": img.name,
+                    "subfolder": subfolder,
+                    "split": split,
+                    "page": page_key(img.name),
+                    "text": text,
+                }
+            )
+    return records
+
+
+def _move_crop(base, subfolder, filename, old_split, new_split):
+    """
+    Move a crop's image and label file from one split to another.
+
+    Args:
+        base: Root directory containing the split subdirectories.
+        subfolder: Region subfolder the crop lives in.
+        filename: Crop image file name.
+        old_split: Current split.
+        new_split: Destination split.
+    """
+    stem = Path(filename).stem
+    pairs = [
+        (
+            base / old_split / "images" / subfolder / filename,
+            base / new_split / "images" / subfolder / filename,
+        ),
+        (
+            base / old_split / "labels" / subfolder / f"{stem}.txt",
+            base / new_split / "labels" / subfolder / f"{stem}.txt",
+        ),
+    ]
+    for src, dst in pairs:
+        if src.exists():
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(src), str(dst))
+
+
+def regroup_by_page(base_dir, seed=42, logger=None):
+    """
+    Re-split existing OCR data grouped by page to remove train/test leakage.
+
+    Every crop of a page is forced into the same split. Whole pages are greedily
+    packed to match SPLIT_WEIGHTS by crop count. Image and label files are moved to
+    their new split and annotations.json is rebuilt complete and consistent with
+    disk.
+
+    Args:
+        base_dir: Root directory containing the split subdirectories.
+        seed: Seed controlling the page shuffle for reproducibility.
+        logger: Optional logger for progress reporting.
+
+    Returns:
+        dict: Per-split crop counts.
+    """
+    base = Path(base_dir)
+    records = _collect_split_crops(base)
+    if not records:
+        if logger:
+            logger.warning(f"No crops found under {base_dir}")
+        return {s: 0 for s in SPLITS}
+
+    unique = {}
+    for r in records:
+        unique.setdefault((r["subfolder"], r["filename"]), r)
+    total = len(unique)
+
+    pages = {}
+    for r in unique.values():
+        pages.setdefault(r["page"], []).append(r)
+
+    rng = random.Random(seed)
+    items = list(pages.items())
+    rng.shuffle(items)
+    items.sort(key=lambda kv: len(kv[1]), reverse=True)
+
+    counts = {s: 0 for s in SPLITS}
+    page_split = {}
+    for key, group in items:
+        need = {s: SPLIT_WEIGHTS[s] * total - counts[s] for s in SPLITS}
+        target = max(need, key=need.get)
+        page_split[key] = target
+        counts[target] += len(group)
+
+    moved = 0
+    for r in records:
+        new = page_split[r["page"]]
+        if new != r["split"]:
+            _move_crop(base, r["subfolder"], r["filename"], r["split"], new)
+            moved += 1
+
+    final = _collect_split_crops(base)
+    annotations = [
+        {
+            "filename": r["filename"],
+            "subfolder": r["subfolder"],
+            "text": r["text"],
+            "split": r["split"],
+        }
+        for r in final
+    ]
+    save_split_annotations(annotations, base)
+
+    final_counts = {s: sum(1 for r in final if r["split"] == s) for s in SPLITS}
+    if logger:
+        duplicates = len(records) - total
+        logger.info(
+            f"Regrouped {total} crops over {len(pages)} pages, moved {moved}, "
+            f"dropped {duplicates} duplicate copies"
+        )
+        for s in SPLITS:
+            pct = final_counts[s] / total * 100 if total else 0
+            logger.info(f"  {s}: {final_counts[s]} ({pct:.1f}%)")
+    return final_counts
+
+
 def collect_images(images_dir):
     """
     Collect all image files from a directory.
@@ -131,6 +314,7 @@ def import_legacy_annotations(input_dir, output_dir, logger):
 
     annotations = {s: [] for s in SPLITS}
     counts = {s: 0 for s in SPLITS}
+    page_to_split = {}
 
     subfolders = [
         d
@@ -164,7 +348,11 @@ def import_legacy_annotations(input_dir, output_dir, logger):
             if not text:
                 continue
 
-            split = assign_split()
+            key = page_key(image_path.name)
+            split = page_to_split.get(key)
+            if split is None:
+                split = assign_split()
+                page_to_split[key] = split
 
             dst_images = output_path / split / "images" / subfolder_name
             dst_labels = output_path / split / "labels" / subfolder_name
@@ -226,3 +414,27 @@ body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
          pointer-events: none; }
 .toast.show { opacity: 1; }
 """
+
+
+def main():
+    """Regroup an existing OCR split by page to remove leakage (CLI entry point)."""
+    import argparse
+    from trocr_handwritten.utils.logging_config import get_logger
+
+    parser = argparse.ArgumentParser(
+        description="Re-split OCR data grouped by page (no train/test leakage)."
+    )
+    parser.add_argument(
+        "base_dir",
+        nargs="?",
+        default="data/ocr",
+        help="Root directory containing train/dev/test (default: data/ocr)",
+    )
+    parser.add_argument("--seed", type=int, default=42, help="Shuffle seed")
+    args = parser.parse_args()
+
+    regroup_by_page(args.base_dir, seed=args.seed, logger=get_logger(__name__))
+
+
+if __name__ == "__main__":
+    main()

--- a/trocr_handwritten/utils/prompt.py
+++ b/trocr_handwritten/utils/prompt.py
@@ -1,0 +1,12 @@
+def load_prompt(prompt_path: str) -> str:
+    """
+    Load a prompt template from file.
+
+    Args:
+        prompt_path: Path to the prompt file.
+
+    Returns:
+        Prompt template string.
+    """
+    with open(prompt_path, "r", encoding="utf-8") as f:
+        return f.read()


### PR DESCRIPTION
## Impact & Purpose
Adds a complete LoRA fine-tuning pipeline for OCR VLMs, with reproducible learning curves, pre-training support (Teklia RecordGold), and zero hardcoding via pydantic settings.

## Overview
Introduces `trocr_handwritten/llm/finetune/` as a self-contained module: data preparation, training, Teklia corpus download, and curve reporting. Also fixes per-item CER/WER clipping, vLLM empty-response retry, and extracts `load_prompt` to avoid circular imports.

## Key Changes
- Added `llm/finetune/` module: `settings.py`, `manifest.py`, `prepare_data.py`, `prepare_teklia.py`, `train_lora.py`, `curve.py`
- `settings.py`: pydantic classes (`LoraSettings`, `DataSettings`, `TekliaSettings`, `CurveSettings`) replacing all hardcoded values
- `manifest.py`: shared `write_manifest` and `proportional_take` utilities used by both data prep scripts
- `train_lora.py`: VLM LoRA SFT trainer with `--init-adapter` for two-stage pre-training (Teklia → our data)
- `prepare_teklia.py`: downloads Teklia RecordGold IIIF images concurrently, builds a fine-tuning manifest
- `curve.py`: prints dev/test CER (mean/median/std) across all model × palier cells
- `metrics.py`: CER and WER clipped at 1.0 per item before aggregation
- `providers/vllm.py`: retries with sampling when vLLM returns an empty response
- `utils/prompt.py`: `load_prompt` extracted from `ocr.py` to break the provider import chain
- `deployment/`: expanded model catalogue, LoRA serving flags, CUDA env tweaks; updated `vllm.md`
- `tests/test_annotation.py`: new test coverage for `page_key`, `assign_split`, `regroup_by_page`
- `utils/annotation.py`: bug fix — group splits by page to prevent label leakage across pages

## Files Changed
- `trocr_handwritten/llm/finetune/__init__.py`: empty package marker
- `trocr_handwritten/llm/finetune/settings.py`: pydantic config for all finetune sub-commands
- `trocr_handwritten/llm/finetune/manifest.py`: shared JSONL write + proportional stratified take
- `trocr_handwritten/llm/finetune/prepare_data.py`: nested stratified subset builder from our OCR splits
- `trocr_handwritten/llm/finetune/prepare_teklia.py`: Teklia RecordGold downloader + manifest writer
- `trocr_handwritten/llm/finetune/train_lora.py`: LoRA fine-tuner (new or continued adapter)
- `trocr_handwritten/llm/finetune/curve.py`: learning curve reporter
- `trocr_handwritten/llm/metrics.py`: clip CER/WER per item at 1.0
- `trocr_handwritten/llm/ocr.py`: import `load_prompt` from `utils.prompt`
- `trocr_handwritten/llm/providers/vllm.py`: retry empty responses with sampling params
- `trocr_handwritten/utils/prompt.py`: new — `load_prompt(path) -> str`
- `trocr_handwritten/llm/deployment/download_models.sh`: expanded model catalogue
- `trocr_handwritten/llm/deployment/serve_vllm.sh`: LoRA serving flags, CUDA env
- `trocr_handwritten/llm/deployment/setup_h100.sh`: minor env fix
- `trocr_handwritten/llm/vllm.md`: LoRA serving documentation
- `trocr_handwritten/utils/annotation.py`: page-level split grouping to prevent leakage
- `tests/test_annotation.py`: tests for split assignment and page grouping

## Testing
```bash
# manifests are bit-for-bit identical to before refactoring
python -m trocr_handwritten.llm.finetune.prepare_data --ocr-dir data/ocr
python -m trocr_handwritten.llm.finetune.curve --ocr-dir data/ocr
pytest tests/test_annotation.py
```

## Review Notes
- `proportional_take` uses `id(r)` for dedup — safe because records are the same Python objects within the strata dict
- `train_lora.py --init-adapter` enables two-stage pre-training: stage-2 loads an existing adapter as trainable and applies its own cosine LR schedule (optimizer state is not preserved between stages)
- `.claude/` is intentionally excluded from all commits